### PR TITLE
babel-plugin-react-transform 2.0.0 is out of beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-core": "^6.0.0",
     "babel-eslint": "^4.1.2",
     "babel-loader": "^6.0.0",
-    "babel-plugin-react-transform": "2.0.0-beta1",
+    "babel-plugin-react-transform": "^2.0.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-react": "^6.0.0",
     "babel-preset-stage-2": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Quick setup for new React.js applications featuring Redux, hot–reloading, PostCSS, react-router and Mocha.",
   "dependencies": {
     "fontfaceobserver": "^1.5.1",
-    "history": "1.13.1",
+    "history": "1.17.0",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",
-    "react-router": "^1.0.0",
+    "react-router": "^1.0.3",
     "redux": "^3.0.0",
     "redux-thunk": "^1.0.0"
   },


### PR DESCRIPTION
Updated to babel-plugin-react-transform 2.0.0 instead of 2.0.0-beta1

Thx @thejameskyle @gaearon