### PR TITLE
Enforce linting in test suite

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,18 @@
 {
-  	"extends": "./node_modules/eslint-config-airbnb/.eslintrc",
+  "extends": "airbnb",
     "env": {
       "browser": true,
       "node": true,
       "mocha": true
     },
-  	"ecmaFeatures": {
-      	"forOf": true,
-      	"jsx": true,
-      	"es6": true
-  	},
-  	"rules": {
-  		"comma-dangle": 0,
-  		"react/prop-types": 0
-  	}
+    "ecmaFeatures": {
+      "forOf": true,
+      "jsx": true,
+      "es6": true
+    },
+    "rules": {
+      "comma-dangle": 0,
+      "react/prop-types": 0,
+      "indent": [2, 2, {"SwitchCase": 1}]
+    }
 }

--- a/js/components/pages/HomePage.react.js
+++ b/js/components/pages/HomePage.react.js
@@ -9,23 +9,23 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
 class HomePage extends Component {
-	render() {
-		const dispatch = this.props.dispatch;
-		const { projectName, ownerName } = this.props.data;
-		return (
-			<div>
-				<h1>Hello World!</h1>
+  render() {
+    const dispatch = this.props.dispatch;
+    const { projectName, ownerName } = this.props.data;
+    return (
+      <div>
+        <h1>Hello World!</h1>
         <h2>This is the demo for the <span className="home__text--red">{ projectName }</span> by <a href={'https://twitter.com/' + ownerName} >@{ ownerName }</a></h2>
         <label className="home__label">Change to your project name:
-					<input className="home__input" type="text" onChange={(evt) => { dispatch(asyncChangeProjectName(evt.target.value)); }} defaultValue="React.js Boilerplate" value={projectName} />
+          <input className="home__input" type="text" onChange={(evt) => { dispatch(asyncChangeProjectName(evt.target.value)); }} defaultValue="React.js Boilerplate" value={projectName} />
         </label>
         <label className="home__label">Change to your name:
           <input className="home__input" type="text" onChange={(evt) => { dispatch(asyncChangeOwnerName(evt.target.value)); }} defaultValue="mxstbr" value={ownerName} />
         </label>
         <Link className="btn" to="/readme">Setup</Link>
-			</div>
-		);
-	}
+      </div>
+    );
+  }
 }
 
 // REDUX STUFF

--- a/js/components/pages/ReadmePage.react.js
+++ b/js/components/pages/ReadmePage.react.js
@@ -8,22 +8,22 @@ import React, { Component} from 'react';
 import { Link } from 'react-router';
 
 export default class AboutPage extends Component {
-	render() {
-		return (
-			<div>
-				<h2>Further Setup</h2>
-				<p>Assuming you have already cloned the repo and ran all the commands from the README (otherwise you would not be here), these are the further steps:</p>
+  render() {
+    return (
+      <div>
+        <h2>Further Setup</h2>
+        <p>Assuming you have already cloned the repo and ran all the commands from the README (otherwise you would not be here), these are the further steps:</p>
 
-				<ol>
-					<li>Replace my name and the package name in the package.json file</li>
-					<li>Replace the two components with your first component</li>
-					<li>Replace the default actions with your first action</li>
-					<li>Delete css/components/_home.css and add the styling for your component</li>
-					<li>And finally, update the unit tests</li>
-				</ol>
+        <ol>
+          <li>Replace my name and the package name in the package.json file</li>
+          <li>Replace the two components with your first component</li>
+          <li>Replace the default actions with your first action</li>
+          <li>Delete css/components/_home.css and add the styling for your component</li>
+          <li>And finally, update the unit tests</li>
+        </ol>
 
-				<Link className="btn" to="/">Home</Link>
-			</div>
-		);
-	}
+        <Link className="btn" to="/">Home</Link>
+      </div>
+    );
+  }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url": "git://github.com/mxstbr/react-boilerplate.git"
   },
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --recursive",
+    "test": "mocha --compilers js:babel-core/register --recursive && eslint .",
     "start": "NODE_ENV=development node server.dev.js",
     "build": "npm run test && NODE_ENV=production webpack --config webpack.prod.config.js --progress --colors -p",
     "serve": "NODE_ENV=production node server.prod.js"


### PR DESCRIPTION
Fixes https://github.com/mxstbr/react-boilerplate/issues/23. Looks like tab characters.

<img width="960" src="https://cloud.githubusercontent.com/assets/1247668/12009086/d69627aa-ac37-11e5-9d6f-024ae678b34e.png">

There's little reason not to lint code as early as possible, and rely on your build system to enforce style. By adding it to run after your test suite, hopefully this will catch bad code before it's merged into master.

Also, you can just `extend: "airbnb"` in eslintrc :smiley: 