### PR TITLE
redux-simple-router

### DIFF
--- a/js/components/pages/HomePage.react.js
+++ b/js/components/pages/HomePage.react.js
@@ -6,12 +6,13 @@
 import { asyncChangeProjectName, asyncChangeOwnerName } from '../../actions/AppActions';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { routeActions } from 'redux-simple-router';
 
 class HomePage extends Component {
   render() {
     const dispatch = this.props.dispatch;
     const { projectName, ownerName } = this.props.data;
+    const { pathname } = this.props.location;
     return (
       <div>
         <h1>Hello World!</h1>
@@ -22,7 +23,9 @@ class HomePage extends Component {
         <label className="home__label">Change to your name:
           <input className="home__input" type="text" onChange={(evt) => { dispatch(asyncChangeOwnerName(evt.target.value)); }} defaultValue="mxstbr" value={ownerName} />
         </label>
-        <Link className="btn" to="/readme">Setup</Link>
+
+        <button className="btn" onClick={ ()=> dispatch(routeActions.push('/readme' )) }>Setup</button>
+        <p> Here is {"'"}{ pathname }{"'"}</p>
       </div>
     );
   }
@@ -33,7 +36,8 @@ class HomePage extends Component {
 // Which props do we want to inject, given the global state?
 function select(state) {
   return {
-    data: state
+    location: state.routing.location,
+    data: state.home
   };
 }
 

--- a/js/components/pages/ReadmePage.react.js
+++ b/js/components/pages/ReadmePage.react.js
@@ -5,10 +5,13 @@
  */
 
 import React, { Component } from 'react';
-import { Link } from 'react-router';
+import { connect } from 'react-redux';
+import { routeActions } from 'redux-simple-router';
 
 export default class ReadmePage extends Component {
   render() {
+    const dispatch = this.props.dispatch;
+    const { pathname } = this.props.location;
     return (
       <div>
         <h2>Further Setup</h2>
@@ -22,8 +25,21 @@ export default class ReadmePage extends Component {
           <li>And finally, update the unit tests</li>
         </ol>
 
-        <Link className="btn" to="/">Home</Link>
+        <button className="btn" onClick={ ()=> dispatch(routeActions.push('/')) }>Back Home</button>
+        <p> Here is {"'"}{ pathname }{"'"}</p>
       </div>
     );
   }
 }
+
+// REDUX STUFF
+
+// Which props do we want to inject, given the global state?
+function select(state) {
+  return {
+    location: state.routing.location
+  };
+}
+
+// Wrap the component to inject dispatch and state into it
+export default connect(select)(ReadmePage);

--- a/js/reducers/rootReducer.js
+++ b/js/reducers/rootReducer.js
@@ -8,6 +8,8 @@ import homeReducer from './homeReducer';
 // Replace line below once you have several reducers with
 // import { combineReducers } from 'redux';
 // const rootReducer = combineReducers({ homeReducer, yourReducer })
-const rootReducer = homeReducer;
+// const rootReducer = homeReducer;
 
-export default rootReducer;
+export default {
+  homeReducer
+}

--- a/js/reducers/rootReducer.js
+++ b/js/reducers/rootReducer.js
@@ -11,5 +11,5 @@ import homeReducer from './homeReducer';
 // const rootReducer = homeReducer;
 
 export default {
-  homeReducer
-}
+  home: homeReducer
+};


### PR DESCRIPTION
The official [redux-simple-router](https://github.com/rackt/redux-simple-router) just released v2.0 and updated its API. I tried to combined it with the repository and it worked well.

I implement its powerful effect : Let `react-router` and `redux` do what they did as usual but keep both in sync. Accordingly , we combined two individual state , our application and **URL**. [This article](http://jlongster.com/A-Simple-Way-to-Route-with-Redux) illustrate the conecpt much clearly.

Without `redux-simple-router` , we used `<Link>` component provided by `react-router` to change URL. For example , `<Link className="btn" to="/readme">Setup</Link>`.

Now , **our application state is contained the URL**. We re-rendered our UI after updating our state by dispatching actions as usual.

```js
<button className="btn" onClick={ ()=> dispatch(routeActions.push('/readme' )) }>Setup</button>
```