### PR TITLE
update Container Component and add redux-simple-router

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -32,6 +32,8 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import FontFaceObserver from 'fontfaceobserver';
 import { browserHistory } from 'react-router';
+import { syncHistory } from 'redux-simple-router';
+const reduxRouterMiddleware = syncHistory(browserHistory);
 
 // Observer loading of Open Sans (to remove open sans, remove the <link> tag in
 // the index.html file and this observer)
@@ -50,10 +52,14 @@ import App from './containers/App/App.react';
 // Import the CSS file, which HtmlWebpackPlugin transfers to the build folder
 import '../node_modules/sanitize.css/dist/sanitize.min.css';
 
-// Create the store with the redux-thunk middleware, which allows us
-// to do asynchronous things in the actions
+/*
+*   Create the store with two middlewares :
+*   1. redux-thunk : Allow us to asynchronous things in the actions
+*   2. reduxRouterMiddleware : Sync dispatched route actions to the history
+*/
+
 import rootReducer from './rootReducer';
-const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
+const createStoreWithMiddleware = applyMiddleware(thunk, reduxRouterMiddleware)(createStore);
 const store = createStoreWithMiddleware(rootReducer);
 
 // Make reducers hot reloadable, see http://mxs.is/googmo

--- a/app/components/Button/Button.react.js
+++ b/app/components/Button/Button.react.js
@@ -7,16 +7,15 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router';
 
 import styles from './Button.css';
 
 function Button(props) {
   const className = props.className ? props.className : styles.button;
 
-  if (props.route) {
+  if (props.handleRoute) {
     return (
-      <Link className={className} to={props.route}>{props.children}</Link>
+      <button className={className} onClick={ props.handleRoute } >{props.children}</button>
     );
   }
 
@@ -27,7 +26,7 @@ function Button(props) {
 
 Button.propTypes = {
   className: React.PropTypes.string,
-  route: React.PropTypes.string,
+  handleRoute: React.PropTypes.func,
   href: React.PropTypes.string,
   onClick: React.PropTypes.func
 };

--- a/app/components/Button/Button.test.js
+++ b/app/components/Button/Button.test.js
@@ -25,9 +25,9 @@ describe('<Button />', () => {
     expect(renderedComponent.find('a').length).toEqual(1);
   });
 
-  it('should render a Link if the route prop is specified', () => {
-    const renderedComponent = shallow(<Button route="/" />);
-    expect(renderedComponent.find('Link').length).toEqual(1);
+  it('should render a button to change route if the handleRoute prop is specified', () => {
+    const renderedComponent = shallow(<Button handleRoute={ ()=> {} } />);
+    expect(renderedComponent.find('button').length).toEqual(1);
   });
 
   it('should handle click events', () => {

--- a/app/components/Button/Button.test.js
+++ b/app/components/Button/Button.test.js
@@ -26,7 +26,7 @@ describe('<Button />', () => {
   });
 
   it('should render a button to change route if the handleRoute prop is specified', () => {
-    const renderedComponent = shallow(<Button handleRoute={ ()=> {} } />);
+    const renderedComponent = shallow(<Button handleRoute="something" />);
     expect(renderedComponent.find('button').length).toEqual(1);
   });
 

--- a/app/containers/HomePage/HomePage.react.js
+++ b/app/containers/HomePage/HomePage.react.js
@@ -17,6 +17,7 @@ class HomePage extends React.Component {
     this.onChangeProjectName = this.onChangeProjectName.bind(this);
     this.onChangeOwnerName = this.onChangeOwnerName.bind(this);
     this.onChangeRoute = this.onChangeRoute.bind(this);
+    this.changeRouteToReadme = this.changeRouteToReadme.bind(this);
   }
   onChangeOwnerName(evt) {
     this.props.changeOwnerName(evt.target.value);
@@ -27,6 +28,10 @@ class HomePage extends React.Component {
 
   onChangeRoute(url) {
     this.props.changeRoute(url);
+  }
+
+  changeRouteToReadme() {
+    this.onChangeRoute('/readme');
   }
 
   render() {
@@ -51,7 +56,7 @@ class HomePage extends React.Component {
             defaultValue="mxstbr" value={ownerName}
           />
         </label>
-        <Button handleRoute= { () => this.onChangeRoute('/readme') } >Setup</Button>
+        <Button handleRoute = { this.changeRouteToReadme }>Setup</Button>
         <p> Here is {"'"}{ pathname }{"'"}</p>
       </div>
     );

--- a/app/containers/HomePage/HomePage.react.js
+++ b/app/containers/HomePage/HomePage.react.js
@@ -6,7 +6,7 @@
 import { asyncChangeProjectName, asyncChangeOwnerName } from './HomePage.actions';
 import React from 'react';
 import { connect } from 'react-redux';
-
+import { routeActions } from 'redux-simple-router';
 import Button from 'Button/Button.react';
 
 import styles from './HomePage.css';
@@ -16,18 +16,22 @@ class HomePage extends React.Component {
     super();
     this.onChangeProjectName = this.onChangeProjectName.bind(this);
     this.onChangeOwnerName = this.onChangeOwnerName.bind(this);
+    this.onChangeRoute = this.onChangeRoute.bind(this);
   }
-
-  onChangeProjectName(evt) {
-    this.props.dispatch(asyncChangeProjectName(evt.target.value));
-  }
-
   onChangeOwnerName(evt) {
-    this.props.dispatch(asyncChangeOwnerName(evt.target.value));
+    this.props.changeOwnerName(evt.target.value);
+  }
+  onChangeProjectName(evt) {
+    this.props.changeProjectName(evt.target.value);
+  }
+
+  onChangeRoute(url) {
+    this.props.changeRoute(url);
   }
 
   render() {
     const { projectName, ownerName } = this.props.data;
+    const { pathname } = this.props.location;
 
     return (
       <div>
@@ -37,30 +41,38 @@ class HomePage extends React.Component {
         </h2>
         <label className={styles.label}>Change to your project name:
           <input className={styles.input} type="text"
-            onChange={this.onChangeProjectName}
+            onChange={ this.onChangeProjectName }
             defaultValue="React.js Boilerplate" value={projectName}
           />
         </label>
         <label className={styles.label}>Change to your name:
           <input className={styles.input} type="text"
-            onChange={this.onChangeOwnerName}
+            onChange={ this.onChangeOwnerName }
             defaultValue="mxstbr" value={ownerName}
           />
         </label>
-        <Button route="/readme">Setup</Button>
+        <Button handleRoute= { () => this.onChangeRoute('/readme') } >Setup</Button>
+        <p> Here is {"'"}{ pathname }{"'"}</p>
       </div>
     );
   }
 }
 
-// REDUX STUFF
-
-// Which props do we want to inject, given the global state?
-function select(state) {
+// react-redux stuff
+function mapStateToProps(state) {
   return {
-    data: state
+    location: state.routing.location,
+    data: state.home
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    changeRoute: (url) => dispatch(routeActions.push(url)),
+    changeProjectName: (value) => dispatch(asyncChangeProjectName(value)),
+    changeOwnerName: (value) => dispatch(asyncChangeOwnerName(value))
   };
 }
 
 // Wrap the component to inject dispatch and state into it
-export default connect(select)(HomePage);
+export default connect(mapStateToProps, mapDispatchToProps)(HomePage);

--- a/app/containers/ReadmePage/ReadmePage.react.js
+++ b/app/containers/ReadmePage/ReadmePage.react.js
@@ -5,32 +5,56 @@
  */
 
 import React from 'react';
-
+import { connect } from 'react-redux';
+import { routeActions } from 'redux-simple-router';
 import Button from 'Button/Button.react';
 
 import styles from './ReadmePage.css';
 
-function ReadmePage() {
-  return (
-    <div>
-      <h2>Further Setup</h2>
-      <p>
-        Assuming you have already cloned the repo and ran all the commands from
-        the README (otherwise you would not be here), these are the further steps:
-      </p>
+class ReadmePage extends React.Component {
+  constructor() {
+    super();
+    this.onChangeRoute = this.onChangeRoute.bind(this);
+  }
+  onChangeRoute(url) {
+    this.props.changeRoute(url);
+  }
+  render() {
+    const { pathname } = this.props.location;
 
-      <ol className={styles.list}>
-        <li>Replace my name and the package name in the package.json file</li>
-        <li>Replace the two components with your first component</li>
-        <li>Replace the default actions with your first action</li>
-        <li>Delete css/components/_home.css and add the styling for your component</li>
-        <li>And finally, update the unit tests</li>
-      </ol>
+    return (
+      <div>
+        <h2>Further Setup</h2>
+        <p>
+          Assuming you have already cloned the repo and ran all the commands from
+          the README (otherwise you would not be here), these are the further steps:
+        </p>
 
-      <Button route="/">Home</Button>
-    </div>
-  );
+        <ol className={styles.list}>
+          <li>Replace my name and the package name in the package.json file</li>
+          <li>Replace the two components with your first component</li>
+          <li>Replace the default actions with your first action</li>
+          <li>Delete css/components/_home.css and add the styling for your component</li>
+          <li>And finally, update the unit tests</li>
+        </ol>
+
+        <Button handleRoute= { () => this.onChangeRoute('/') } >Home</Button>
+        <p> Here is {"'"}{ pathname }{"'"}</p>
+      </div>
+    );
+  }
 }
 
+function mapStateToProps(state) {
+  return {
+    location: state.routing.location
+  };
+}
 
-export default ReadmePage;
+function mapDispatchToProps(dispatch) {
+  return {
+    changeRoute: (url) => dispatch(routeActions.push(url))
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReadmePage);

--- a/app/containers/ReadmePage/ReadmePage.react.js
+++ b/app/containers/ReadmePage/ReadmePage.react.js
@@ -15,10 +15,17 @@ class ReadmePage extends React.Component {
   constructor() {
     super();
     this.onChangeRoute = this.onChangeRoute.bind(this);
+    this.changeRouteToHome = this.changeRouteToHome.bind(this);
   }
+
   onChangeRoute(url) {
     this.props.changeRoute(url);
   }
+
+  changeRouteToHome() {
+    this.onChangeRoute('/');
+  }
+
   render() {
     const { pathname } = this.props.location;
 
@@ -38,7 +45,7 @@ class ReadmePage extends React.Component {
           <li>And finally, update the unit tests</li>
         </ol>
 
-        <Button handleRoute= { () => this.onChangeRoute('/') } >Home</Button>
+        <Button handleRoute= { this.changeRouteToHome } >Home</Button>
         <p> Here is {"'"}{ pathname }{"'"}</p>
       </div>
     );

--- a/app/rootReducer.js
+++ b/app/rootReducer.js
@@ -3,11 +3,11 @@
  * If we were to do this in store.js, reducers wouldn't be hot reloadable.
  */
 
-import HomePageReducer from './containers/HomePage/HomePage.reducer';
+import { combineReducers } from 'redux';
+import { routeReducer } from 'redux-simple-router';
+import homeReducer from './containers/HomePage/HomePage.reducer';
 
-// Replace line below once you have several reducers with
-// import { combineReducers } from 'redux';
-// const rootReducer = combineReducers({ HomePage.reducer, yourReducer })
-const rootReducer = HomePageReducer;
-
-export default rootReducer;
+export default combineReducers({
+  routing: routeReducer,
+  home: homeReducer
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-redux": "^4.0.0",
     "react-router": ">2.0.0-rc",
     "redux": "^3.0.0",
+    "redux-simple-router": "^2.0.3",
     "redux-thunk": "^1.0.0",
     "sanitize.css": "3.0.0"
   },


### PR DESCRIPTION
I sent [#88](https://github.com/mxstbr/react-boilerplate/pull/88) which I combined the repo with  [redux-simple-router](https://github.com/rackt/redux-simple-router) a few days ago.

Sorry for sending the new PR late , because I had busy weekend for the past two day. There are two main points about the new PR.

1. Add the [redux-simple-router](https://github.com/rackt/redux-simple-router) like what I did in [#88](https://github.com/mxstbr/react-boilerplate/pull/88)

2. Extract component methods(`onChangeProjectName` ,  `onChangeOwnerName` ...) from `HomePage` component. I think this made **Presentational Components** (`HomePage` , `ReadmePage`) more "PURE" and clear. Then, export Container components **connect()-ed**  to Redux by means of `mapDispatchToProps` and `mapStateToProps` suggested by [react-redux](https://github.com/rackt/react-redux/tree/b2b9f077600d6a648e75ba0bee38131baa68a58d).

The other problem is when I ran *lint* ,  the Error : "JSX props should not use arrow functions  react/jsx-no-bind" appeared. I thought the sytax of the new PR is correct. Maybe we can modify the lint ?
