### PR TITLE
Fix typo in Babel Loader for Hot-Reload

### DIFF
--- a/webpack/webpack.base.babel.js
+++ b/webpack/webpack.base.babel.js
@@ -18,7 +18,7 @@ module.exports = (options) => {
         test: /\.js$/, // Transform all .js files required somewhere with Babel
         loader: 'babel',
         exclude: path.join(__dirname, '..', '/node_modules/'),
-        query: options.query,
+        query: options.babelQuery,
       }, {
         test: /\.css$/, // Transform all .css files required somewhere with PostCSS
         loader: options.cssLoaders


### PR DESCRIPTION
Brings the correct query so react-transform can hot-reload components properly.