### PR TITLE
Fix warning for handleRoute prop

### DIFF
--- a/app/components/Button/Button.test.js
+++ b/app/components/Button/Button.test.js
@@ -26,7 +26,7 @@ describe('<Button />', () => {
   });
 
   it('should render a button to change route if the handleRoute prop is specified', () => {
-    const renderedComponent = shallow(<Button handleRoute="something" />);
+    const renderedComponent = shallow(<Button handleRoute={function handler() {}} />);
     expect(renderedComponent.find('button').length).toEqual(1);
   });
 


### PR DESCRIPTION
Pass a function instead of a string to avoid warning.

