### PR TITLE
Styelint for CSS with CLI configuration

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+  		"color-hex-case": "upper",
+  		"string-quotes": "single",
+      "indentation": 4,
+    }
+}

--- a/app/components/Anchor/styles.css
+++ b/app/components/Anchor/styles.css
@@ -1,7 +1,7 @@
 .link {
-  color: #41ADDD;
+    color: #41ADDD;
 }
 
 .link:hover {
-  color: #6CC0E5;
+    color: #6CC0E5;
 }

--- a/app/components/Button/styles.css
+++ b/app/components/Button/styles.css
@@ -1,8 +1,8 @@
 .button {
-	background-color: skyblue;
-	padding: 0.5em;
-	color: #FEFEFE;
-	border-radius: 3px;
-	text-decoration: none;
-	display: inline-block;
+    background-color: skyblue;
+    padding: 0.5em;
+    color: #FEFEFE;
+    border-radius: 3px;
+    text-decoration: none;
+    display: inline-block;
 }

--- a/app/components/Footer/styles.css
+++ b/app/components/Footer/styles.css
@@ -1,8 +1,8 @@
 .footer {
-  margin: 3em 0;
-  display: flex;
-  justify-content: space-between;
-  margin: 3em 0;
-  padding-top: 3em;
-  border-top: 1px solid #666;
+    margin: 3em 0;
+    display: flex;
+    justify-content: space-between;
+    margin: 3em 0;
+    padding-top: 3em;
+    border-top: 1px solid #666;
 }

--- a/app/components/Heading1/styles.css
+++ b/app/components/Heading1/styles.css
@@ -1,4 +1,4 @@
 .heading1 {
-  font-size: 2em;
-	margin-bottom: 0.25em;
+    font-size: 2em;
+    margin-bottom: 0.25em;
 }

--- a/app/components/Heading2/styles.css
+++ b/app/components/Heading2/styles.css
@@ -1,3 +1,3 @@
 .heading2 {
-  font-size: 1.5em;
+    font-size: 1.5em;
 }

--- a/app/containers/App/styles.css
+++ b/app/containers/App/styles.css
@@ -1,30 +1,30 @@
 /* Global styles */
 
 body {
-	font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 body.jsOpenSansLoaded {
-	font-family: 'Open Sans', Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: 'Open Sans', Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 
 .wrapper {
-	max-width: calc(768px + 16px * 2);
-	margin: 0 auto;
-	display: -webkit-flex;
-	display: -ms-flexbox;
-	display: flex;
-	height: 100%;
-	padding: 0 16px;
-	flex-direction: column;
+    max-width: calc(768px + 16px * 2);
+    margin: 0 auto;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    height: 100%;
+    padding: 0 16px;
+    flex-direction: column;
 }
 
 .logoWrapper {
-	padding: 2em 0;
+    padding: 2em 0;
 }
 
 .logo {
-	max-height: 5em;
-	margin: 0 auto;
-	display: block;
+    max-height: 5em;
+    margin: 0 auto;
+    display: block;
 }

--- a/app/containers/HomePage/styles.css
+++ b/app/containers/HomePage/styles.css
@@ -1,32 +1,32 @@
 .textSection {
-	margin: 3em auto;
+    margin: 3em auto;
 }
 
 .textSection:first-child {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 :global(p) {
-  font-family: Georgia, Times, 'Times New Roman', serif;
-  line-height: 1.5em;
+    font-family: Georgia, Times, 'Times New Roman', serif;
+    line-height: 1.5em;
 }
 
 .list {
-  font-family: Georgia, Times, 'Times New Roman', serif;
-  padding-left: 1.75em;
+    font-family: Georgia, Times, 'Times New Roman', serif;
+    padding-left: 1.75em;
 }
 
 .listItem {
-	margin: 1em 0;
+    margin: 1em 0;
 }
 
 .link {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 .code {
-  font-size: 0.75em;
-  background-color: $very-light-grey;
-  padding: 0.125em 0.5em;
-  border-radius: 1px;
+    font-size: 0.75em;
+    background-color: $very-light-grey;
+    padding: 0.125em 0.5em;
+    border-radius: 1px;
 }

--- a/app/containers/ReadmePage/styles.css
+++ b/app/containers/ReadmePage/styles.css
@@ -1,3 +1,3 @@
 .list {
-  margin-left: 1.5em;
+    margin-left: 1.5em;
 }

--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -90,8 +90,17 @@ This will run a server that's accessible on the entire world and shows the versi
 
 ## Linting
 
-Lint your JavaScript with this command.
+Lint your JavaScript and CSS with this command.
 
 ```Shell
 $ npm run lint
 ```
+
+Want to lint your JavaScript and CSS seperately? 
+
+```Shell
+$ npm run lint:js
+$ npm run lint:css
+```
+
+> Note: CSS Linting uses [Stylelint](http://stylelint.io/) default configuration with a few custom extends. To edit the custom extends open `.stylelintrc`

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-addons-test-utils": "^0.14.6",
     "react-router-redux": "^2.1.0",
     "style-loader": "^0.13.0",
+    "stylelint": "^4.1.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.11",
     "webpack-dev-server": "^1.14.1"
@@ -77,7 +78,9 @@
     "serve": "NODE_ENV=production node webpack/server.prod.js",
     "pagespeed": "./webpack/pagespeed",
     "setup": "NODE_ENV=initialisation ./webpack/init",
-    "lint": "eslint .",
+    "lint:js": "eslint .",
+    "lint:css": "stylelint ./app/**/*.css || true",
+    "lint": "npm run lint:js & npm run lint:css",
     "test": "NODE_ENV=test karma start webpack/karma.conf.js --single-run",
     "prebuild": "npm run test",
     "pretest": "npm run lint",


### PR DESCRIPTION
created: 
- .stylelintrc

updated: 
- CSS files to 4 spaces
- Linting commands
    - npm run lint, npm run lint:js, npm run lint:css 
    - note I added "|| true" to avoid an Exit 2 npm occurrence on CSS lint:    https://github.com/npm/npm/issues/6124
- docs/general/commands.md