### PR TITLE
Implement Coveralls task & badge.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install:
 notifications:
   email:
     on_failure: change
+after_success: 'npm run coveralls'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React.js Boilerplate [![Dependency Status][dep-status-img]][dep-status-link] [![devDependency Status][dev-dep-status-img]][dev-dep-status-link] [![Build Status][ci-img]][ci]
+# React.js Boilerplate [![Dependency Status][dep-status-img]][dep-status-link] [![devDependency Status][dev-dep-status-img]][dev-dep-status-link] [![Build Status][ci-img]][ci-link] [![Code Coverage][coverage-img]][coverage-link]
 
 Quick setup for new performance orientated, offline–first React.js applications featuring Redux, hot–reloading, PostCSS, react-router, ServiceWorker, AppCache, FontFaceObserver and Mocha.
 
@@ -9,7 +9,9 @@ Made with :heart: by [Max Stoiber](https://twitter.com/mxstbr) and [contributors
 [dev-dep-status-img]: https://david-dm.org/mxstbr/react-boilerplate/v3.0.0/dev-status.svg
 [dev-dep-status-link]: https://david-dm.org/mxstbr/react-boilerplate/v3.0.0#info=devDependencies
 [ci-img]: https://travis-ci.org/mxstbr/react-boilerplate.svg?branch=v3.0.0
-[ci]: https://travis-ci.org/mxstbr/react-boilerplate?branch=v3.0.0
+[ci-link]: https://travis-ci.org/mxstbr/react-boilerplate?branch=v3.0.0
+[coverage-link]: https://coveralls.io/r/mxstbr/react-boilerplate?branch=v3.0.0
+[coverage-img]: https://coveralls.io/r/mxstbr/react-boilerplate/badge.svg?branch=v3.0.0
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chai-enzyme": "^0.3.0",
     "chalk": "^1.1.1",
     "cheerio": "^0.19.0",
+    "coveralls": "^2.11.6",
     "css-loader": "^0.23.1",
     "css-modules-require-hook": "^2.1.0",
     "cssnano": "^3.4.0",
@@ -105,7 +106,8 @@
     "test:watch": "npm run test -- --auto-watch --no-single-run",
     "test:firefox": "npm run test -- --browsers Firefox",
     "test:safari": "npm run test -- --browsers Safari",
-    "test:ie": "npm run test -- --browsers IE"
+    "test:ie": "npm run test -- --browsers IE",
+    "coveralls": "cat ./coverage/lcov/lcov.info | ./node_modules/.bin/coveralls"
   },
   "pre-commit": "lint:staged",
   "author": "Max Stoiber",


### PR DESCRIPTION
- [x] install `coveralls` npm package
- [x] add an npm script to submit coverage data to coveralls
- [x] add a post-deploy hook to travis.yml to run that npm script
- [x] add a badge in README