### PR TITLE
Remove webpack --progress from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=development node webpack/server.dev.js",
-    "build": "NODE_ENV=production webpack --config webpack/webpack.prod.babel.js --progress --colors -p",
+    "build": "NODE_ENV=production webpack --config webpack/webpack.prod.babel.js --colors -p",
     "serve": "NODE_ENV=production node webpack/server.prod.js",
     "pagespeed": "./webpack/pagespeed",
     "setup": "NODE_ENV=initialisation ./webpack/init",


### PR DESCRIPTION
[`--progress` breaks deployment on Heroku](https://github.com/webpack/webpack/issues/1553)

Not sure how everyone's deploying their projects and what you're checking in etc but I've added `"postinstall": "npm run build"` to my package.json; kinda annoying not being able to build on a server!

Is this generalized enough to add as a default?