### PR TITLE
Fix typo in webpack config

### DIFF
--- a/makewebpackconfig.js
+++ b/makewebpackconfig.js
@@ -70,7 +70,7 @@ module.exports = function(options) {
 
   return {
     entry: entry,
-    output: { // Compile into js/build.js
+    output: { // Compile into js/bundle.js
       path: path.resolve(__dirname, 'build'),
       filename: "js/bundle.js"
     },


### PR DESCRIPTION
## Scope

`s/build.js/bundle.js/`

Alternative would be to remove those comments, but since I think the idea in the boilerplate is to be more  verbose than normal, I think just fixing the typo should do it :)