### PR TITLE
Container Generator requires CSS file that is not created

### DIFF
--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -89,7 +89,7 @@ module.exports = {
     if (data.wantCSS) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/styles.css',
+        path: '../../app/containers/{{properCase name}}/{{dashCase name}}.css',
         templateFile: './container/styles.css.hbs',
         abortOnFail: true,
       });

--- a/internals/generators/container/index.js
+++ b/internals/generators/container/index.js
@@ -89,7 +89,7 @@ module.exports = {
     if (data.wantCSS) {
       actions.push({
         type: 'add',
-        path: '../../app/containers/{{properCase name}}/{{dashCase name}}.css',
+        path: '../../app/containers/{{properCase name}}/styles.css',
         templateFile: './container/styles.css.hbs',
         abortOnFail: true,
       });

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -19,7 +19,7 @@ import {{this}} from '{{this}}';
 {{/if}}
 
 {{#if wantCSS}}
-import styles from './{{ dashCase name }}.css';
+import styles from './styles.css';
 {{/if}}
 
 class {{ properCase name }} extends React.Component {


### PR DESCRIPTION
In a default install of v3.0.0 (cloned about 15 minutes ago), generating a new Container and then attempting to require it on the homepage throws the following error (assuming the Container is named `LoginForm`).

```
./app/containers/LoginForm/index.js
Module not found: Error: Cannot resolve 'file' or 'directory' ./login-form.css in [localpath]/app/containers/LoginForm
resolve file
  [localpath]/app/containers/LoginForm/login-form.css doesn't exist
  [localpath]/app/containers/LoginForm/login-form.css.js doesn't exist
  [localpath]/app/containers/LoginForm/login-form.css.jsx doesn't exist
  [localpath]/app/containers/LoginForm/login-form.css.react.js doesn't exist
resolve directory
  [localpath]/app/containers/LoginForm/login-form.css/package.json doesn't exist (directory description file)
  [localpath]/app/containers/LoginForm/login-form.css doesn't exist (directory default file)
[[localpath]/app/containers/LoginForm/login-form.css]
[[localpath]/app/containers/LoginForm/login-form.css.js]
[[localpath]/app/containers/LoginForm/login-form.css.jsx]
[[localpath]/app/containers/LoginForm/login-form.css.react.js]
 @ ./app/containers/LoginForm/index.js 33:17-44
```

This is because the Container generator has a hardcoded CSS file path of `styles.css`:

```
path: '../../app/containers/{{properCase name}}/styles.css',
```

But the created component imports a module with the `dashCase` version of the component name:

```js
import styles from './{{ dashCase name }}.css';
```

This PR updates the generator to output a `dashCase` version of the css file inside the container directory, so that no error is thrown and also so an app full of components is also not full of `styles.css` files.

This resolves the error and allows the app to execute normally.