### PR TITLE
Supporting older browser that does not have Promise

### DIFF
--- a/makewebpackconfig.js
+++ b/makewebpackconfig.js
@@ -64,9 +64,12 @@ module.exports = function(options) {
     ]
   }
 
-  plugins.push(new AppCachePlugin({ // AppCache should be in both prod and dev env
-    exclude: ['.htaccess'] // No need to cache that. See https://support.hostgator.com/articles/403-forbidden-or-no-permission-to-access
-  }));
+  plugins.push(
+    new AppCachePlugin({ // AppCache should be in both prod and dev env
+      exclude: ['.htaccess'] // No need to cache that. See https://support.hostgator.com/articles/403-forbidden-or-no-permission-to-access
+    }),
+    new webpack.ProvidePlugin({'Promise': 'promise'}), // Polyfill for promise for older browser
+  );
 
   return {
     entry: entry,

--- a/makewebpackconfig.js
+++ b/makewebpackconfig.js
@@ -68,7 +68,7 @@ module.exports = function(options) {
     new AppCachePlugin({ // AppCache should be in both prod and dev env
       exclude: ['.htaccess'] // No need to cache that. See https://support.hostgator.com/articles/403-forbidden-or-no-permission-to-access
     }),
-    new webpack.ProvidePlugin({'Promise': 'promise'}), // Polyfill for promise for older browser
+    new webpack.ProvidePlugin({'Promise': 'promise'}) // Polyfill for promise for older browser
   );
 
   return {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "fontfaceobserver": "^1.5.1",
     "history": "1.17.0",
+    "promise": "^7.1.1",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",


### PR DESCRIPTION
This request resolves #228. By adding the promise polyfill the demo now runs on stock Samsung browser on the S3. Tried a couple of other polyfills out there promise-polyfill and es6-promise but they seem to fix the issue but break things for newer browser. This one https://www.promisejs.org/ worked on old and new.