### PR TITLE
Added line ending settings for *.js files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,7 @@
 *.scss text
 *.less text
 *.styl text
-*.js text
+*.js text eol=lf
 *.coffee text
 *.json text
 *.htm text


### PR DESCRIPTION
Added `eol=lf` to *.js files in .gitattributes, see issue #249 