### PR TITLE
Use Standard Scroll

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -20,7 +20,7 @@ import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import FontFaceObserver from 'fontfaceobserver';
-import useScroll from 'scroll-behavior/lib/useScrollToTop';
+import useScroll from 'scroll-behavior/lib/useStandardScroll';
 import configureStore from './store';
 
 // Observe loading of Open Sans (to remove open sans, remove the <link> tag in


### PR DESCRIPTION
Swapped `useScrollToTop` to `useStandardScroll` in response to #275. Feel free to close if the current behavior is desired. Was there a particular reason we were scrolling to top each time before?