### PR TITLE
Centralising addition of sanitize.css via webpack config

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -8,9 +8,6 @@
 
 import React from 'react';
 
-// Import the CSS reset, which HtmlWebpackPlugin transfers to the build folder
-import 'sanitize.css/sanitize.css';
-
 import Img from 'Img';
 import Footer from 'Footer';
 import Banner from './banner-metal.jpg';

--- a/internals/webpack/webpack.dev.babel.js
+++ b/internals/webpack/webpack.dev.babel.js
@@ -16,6 +16,7 @@ module.exports = require('./webpack.base.babel')({
   entry: [
     'eventsource-polyfill', // Necessary for hot reloading with IE
     'webpack-hot-middleware/client',
+    'sanitize.css/sanitize.css', // Baseline styles
     path.join(process.cwd(), 'app/app.js'), // Start with js/app.js
   ],
 

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -13,6 +13,7 @@ const postcssReporter = require('postcss-reporter');
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
   entry: [
+    'sanitize.css/sanitize.css', // Baseline styles
     path.join(process.cwd(), 'app/app.js'),
   ],
 


### PR DESCRIPTION
If we want santitize.css to be a centralised addition then this is an alternative approach to consider.