### PR TITLE
Remove sanitize.css from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "postcss-reporter": "^1.3.3",
     "psi": "^2.0.3",
     "rimraf": "^2.5.2",
-    "sanitize.css": "^3.3.0",
     "shelljs": "^0.7.0",
     "sinon": "^2.0.0-pre",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
Duplicated sanitize.css on dependencies and devDependencies.
Remove the warning: `npm WARN package.json Dependency 'sanitize.css' exists in both dependencies and devDependencies, using 'sanitize.css@^3.3.0' from dependencies`