### PR TITLE
Fix webpack config for NODE_ENV use in code

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -46,7 +46,7 @@ module.exports = (options) => ({
       fetch: 'exports?self.fetch!whatwg-fetch',
     }),
 
-    // Always expose NODE_ENV to webpack, in order tocuse `process.env.NODE_ENV`
+    // Always expose NODE_ENV to webpack, in order to use `process.env.NODE_ENV`
     // inside your code for any environment checks; UglifyJS will automatically
     // drop any unreachable code.
     new webpack.DefinePlugin({

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -45,6 +45,15 @@ module.exports = (options) => ({
       // make fetch available
       fetch: 'exports?self.fetch!whatwg-fetch',
     }),
+
+    // Always expose NODE_ENV to webpack, in order tocuse `process.env.NODE_ENV`
+    // inside your code for any environment checks; UglifyJS will automatically
+    // drop any unreachable code.
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+      },
+    }),
   ]),
   postcss: () => options.postcssPlugins,
   resolve: {

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -76,14 +76,6 @@ module.exports = require('./webpack.base.babel')({
     // Extract the CSS into a seperate file
     new ExtractTextPlugin('[name].[contenthash].css'),
 
-    // Set the process.env to production so React includes the production
-    // version of itself
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
-
     // Put it in the end to capture all the HtmlWebpackPlugin's
     // assets manipulations and do leak its manipulations to HtmlWebpackPlugin
     new OfflinePlugin({

--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -51,7 +51,7 @@ module.exports = {
 
   plugins: [
 
-    // Always expose NODE_ENV to webpack, in order tocuse `process.env.NODE_ENV`
+    // Always expose NODE_ENV to webpack, in order to use `process.env.NODE_ENV`
     // inside your code for any environment checks; UglifyJS will automatically
     // drop any unreachable code.
     new webpack.DefinePlugin({

--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -3,7 +3,7 @@
  */
 
 const path = require('path');
-
+const webpack = require('webpack');
 const modules = [
   'app',
   'node_modules',
@@ -48,6 +48,17 @@ module.exports = {
       },
     ],
   },
+
+  plugins: [
+
+    // Always expose NODE_ENV to webpack, in order tocuse `process.env.NODE_ENV`
+    // inside your code for any environment checks; UglifyJS will automatically
+    // drop any unreachable code.
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+      },
+    })],
 
   // Some node_modules pull in Node-specific dependencies.
   // Since we're running in a browser we have to stub them out. See:


### PR DESCRIPTION
In dev and test phases, NODE_ENV was not correctly set and use of `process.env.NODE_ENV` always returned `undefined` in app code execution.
Config for prod was put together with dev in webpack.base.babel.js 

#301 