### PR TITLE
Use Record immutable for state

### DIFF
--- a/app/containers/App/reducer.js
+++ b/app/containers/App/reducer.js
@@ -15,19 +15,30 @@ import {
   LOAD_REPOS,
   LOAD_REPOS_ERROR,
 } from './constants';
-import { fromJS } from 'immutable';
+import { Record } from 'immutable';
 
-// The initial state of the App
-const initialState = fromJS({
+// A Record is an immutable similar to Map, but can be accessed
+// with dot notation
+// see https://facebook.github.io/immutable-js/docs/#/Record
+const UserDataRecord = Record({ // eslint-disable-line
+  repositories: false,
+},
+'UserData'
+);
+
+const GlobalRecord = Record({ // eslint-disable-line
   loading: false,
   error: false,
   currentUser: false,
-  userData: fromJS({
-    repositories: false,
-  }),
-});
+  userData: new UserDataRecord({}),
+},
+'GlobalRecord'
+);
 
-function homeReducer(state = initialState, action) {
+// The initial state of the App initialised by default record
+const initialState = new GlobalRecord({});
+
+function globalReducer(state = initialState, action) {
   switch (action.type) {
     case LOAD_REPOS:
       return state
@@ -48,4 +59,4 @@ function homeReducer(state = initialState, action) {
   }
 }
 
-export default homeReducer;
+export default globalReducer;

--- a/app/containers/App/tests/reducer.test.js
+++ b/app/containers/App/tests/reducer.test.js
@@ -1,28 +1,36 @@
-import expect from 'expect';
+import { expect } from 'chai';
 import appReducer from '../reducer';
 import {
   loadRepos,
   reposLoaded,
   repoLoadingError,
 } from '../actions';
-import { fromJS } from 'immutable';
+import { Record } from 'immutable';
 
 describe('appReducer', () => {
   let state;
   beforeEach(() => {
-    state = fromJS({
+    const UserDataRecord = Record({ // eslint-disable-line
+      repositories: false,
+    },
+    'UserData'
+    );
+
+    const GlobalRecord = Record({ // eslint-disable-line
       loading: false,
       error: false,
       currentUser: false,
-      userData: fromJS({
-        repositories: false,
-      }),
-    });
+      userData: new UserDataRecord({}),
+    },
+    'GlobalRecord'
+    );
+
+    state = new GlobalRecord({});
   });
 
   it('should return the initial state', () => {
     const expectedResult = state;
-    expect(appReducer(undefined, {})).toEqual(expectedResult);
+    expect(appReducer(undefined, {})).to.equal(expectedResult);
   });
 
   it('should handle the loadRepos action correctly', () => {
@@ -31,7 +39,7 @@ describe('appReducer', () => {
       .set('error', false)
       .setIn(['userData', 'repositories'], false);
 
-    expect(appReducer(state, loadRepos())).toEqual(expectedResult);
+    expect(appReducer(state, loadRepos())).to.equal(expectedResult);
   });
 
   it('should handle the reposLoaded action correctly', () => {
@@ -44,7 +52,7 @@ describe('appReducer', () => {
       .set('loading', false)
       .set('currentUser', username);
 
-    expect(appReducer(state, reposLoaded(fixture, username))).toEqual(expectedResult);
+    expect(appReducer(state, reposLoaded(fixture, username))).to.equal(expectedResult);
   });
 
   it('should handle the repoLoadingError action correctly', () => {
@@ -55,6 +63,6 @@ describe('appReducer', () => {
       .set('error', fixture)
       .set('loading', false);
 
-    expect(appReducer(state, repoLoadingError(fixture))).toEqual(expectedResult);
+    expect(appReducer(state, repoLoadingError(fixture))).to.equal(expectedResult);
   });
 });

--- a/app/containers/HomePage/reducer.js
+++ b/app/containers/HomePage/reducer.js
@@ -13,12 +13,15 @@
 import {
   CHANGE_USERNAME,
 } from './constants';
-import { fromJS } from 'immutable';
+import { Record } from 'immutable';
 
-// The initial state of the App
-const initialState = fromJS({
-  username: '',
-});
+// A Record is an immutable similar to Map, but can be accessed
+// with dot notation
+// see https://facebook.github.io/immutable-js/docs/#/Record
+const HomeRecord = Record({ username: '' }, 'HomeRecord'); // eslint-disable-line
+
+// The initial state of the App initialised by default record
+const initialState = new HomeRecord({});
 
 function homeReducer(state = initialState, action) {
   switch (action.type) {

--- a/app/containers/HomePage/tests/reducer.test.js
+++ b/app/containers/HomePage/tests/reducer.test.js
@@ -1,27 +1,26 @@
-import expect from 'expect';
+import { expect } from 'chai';
 import homeReducer from '../reducer';
 import {
   changeUsername,
 } from '../actions';
-import { fromJS } from 'immutable';
+import { Record } from 'immutable';
 
 describe('homeReducer', () => {
   let state;
   beforeEach(() => {
-    state = fromJS({
-      username: '',
-    });
+    const HomeRecord = Record({ username: '' }, 'HomeRecord'); // eslint-disable-line
+    state = new HomeRecord({});
   });
 
   it('should return the initial state', () => {
     const expectedResult = state;
-    expect(homeReducer(undefined, {})).toEqual(expectedResult);
+    expect(homeReducer(undefined, {})).to.equal(expectedResult);
   });
 
   it('should handle the changeUsername action correctly', () => {
     const fixture = 'mxstbr';
     const expectedResult = state.set('username', fixture);
 
-    expect(homeReducer(state, changeUsername(fixture))).toEqual(expectedResult);
+    expect(homeReducer(state, changeUsername(fixture))).to.equal(expectedResult);
   });
 });

--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -5,8 +5,10 @@ import 'babel-polyfill';
 import sinon from 'sinon';
 import chai from 'chai';
 import chaiEnzyme from 'chai-enzyme';
+import chaiImmutable from 'chai-immutable';
 
 chai.use(chaiEnzyme());
+chai.use(chaiImmutable);
 
 global.chai = chai;
 global.sinon = sinon;

--- a/package.json
+++ b/package.json
@@ -69,14 +69,26 @@
     },
     "rules": {
       "import/no-unresolved": 2,
-      "comma-dangle": [2, "always-multiline"],
-      "indent": [2, 2, { "SwitchCase": 1 }],
+      "comma-dangle": [
+        2,
+        "always-multiline"
+      ],
+      "indent": [
+        2,
+        2,
+        {
+          "SwitchCase": 1
+        }
+      ],
       "no-console": 1,
       "max-len": 0,
       "prefer-template": 2,
       "no-use-before-define": 0,
       "newline-per-chained-call": 0,
-      "arrow-body-style": [2, "as-needed"],
+      "arrow-body-style": [
+        2,
+        "as-needed"
+      ],
       "jsx-a11y/href-no-hash": 2,
       "jsx-a11y/label-has-for": 2,
       "jsx-a11y/mouse-events-have-key-events": 2,
@@ -150,6 +162,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.4.2",
+    "chai-immutable": "^1.5.4",
     "cheerio": "^0.20.0",
     "coveralls": "^2.11.9",
     "cross-env": "^1.0.7",


### PR DESCRIPTION
Record immutable allows to use `.get`, `.set`, `.merge` .... like `Immutable.Map` but also the dot notation.
```javascript
const r = new Record({a: 1, b: 2})
console.log(r.a)     // 1
```

With records, the state is still serializable with [transit-immutable-js](https://github.com/glenjamin/transit-immutable-js)

```javascript
import transit from 'transit-immutable-js'
import { Record, Set, List, Map } from 'immutable'

const LoginRecord = Record(
  {
    user: false
  },
  'LoginRecord'
)

const LoadRecord = Record(
  {
    loading: false,
    error: false,
    qcm: false
  },
  'LoadRecord')

const InnerRecord = Record(
  {
    dumb: 'dumber'
  },
  'InnerRecord')

const LaunchRecord = Record(
  {
    current: 1,
    answer: Set([]),
    answers: List([]),
    inner: new InnerRecord({})
  },
  'LaunchRecord')

const store = Map({
  login: new LoginRecord({}),
  load: new LoadRecord({}),
  launch: new LaunchRecord({})
})
console.log(`store : ${store}\n`)

var recordTransit = transit.withRecords(
  [
    LoginRecord,
    LoadRecord,
    LaunchRecord,
    InnerRecord
  ])

const serializedStore = recordTransit.toJSON(store)
console.log(` serializedStore : ${serializedStore}\n`)

const store2 = recordTransit.fromJSON(serializedStore)
console.log(`store2 : ${store2}\n`)

console.log(`store === store2 ?      --->   ${store===store2}`) // false
console.log(`store equals store2 ?   --->   ${store.equals(store2)}`) //true

```
