### PR TITLE
Added missing loaders for fonts files and svg

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -34,6 +34,21 @@ module.exports = (options) => ({
     }, {
       test: /\.jpe?g$|\.gif$|\.png$/i,
       loader: 'url-loader?limit=10000',
+    }, { 
+      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, 
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff' 
+    }, { 
+      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, 
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff'
+    }, { 
+      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, 
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/octet-stream' 
+    }, { 
+      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, 
+      loader: 'file?name=fonts/[name].[hash].[ext]' 
+    }, { 
+      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, 
+      loader: 'file?name=images/[name].[hash].[ext]&mimetype=image/svg+xml' 
     }, {
       test: /\.html$/,
       loader: 'html-loader',

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -32,23 +32,20 @@ module.exports = (options) => ({
       include: /node_modules/,
       loaders: ['style-loader', 'css-loader'],
     }, {
-      test: /\.jpe?g$|\.gif$|\.png$/i,
+      test: /\.jpe?g$|\.gif$|\.png$|\.svg$/i,
       loader: 'url-loader?limit=10000',
-    }, { 
-      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, 
-      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff' 
-    }, { 
-      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, 
-      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff'
-    }, { 
-      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, 
-      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/octet-stream' 
-    }, { 
-      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, 
-      loader: 'file?name=fonts/[name].[hash].[ext]' 
-    }, { 
-      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, 
-      loader: 'file?name=images/[name].[hash].[ext]&mimetype=image/svg+xml' 
+    }, {
+      test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff',
+    }, {
+      test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/font-woff',
+    }, {
+      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file?name=fonts/[name].[hash].[ext]&mimetype=application/octet-stream',
+    }, {
+      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file?name=fonts/[name].[hash].[ext]',
     }, {
       test: /\.html$/,
       loader: 'html-loader',


### PR DESCRIPTION
While trying to integrate Semantic UI to this boilerplate, I noticed that the webpack config was missing file loaders for font files and svg files used by semantic-ui. I thought it could be usefull to others so I thought I'd share it. 

Found the fix in this thread https://github.com/Semantic-Org/Semantic-UI/issues/3533

Not included in the PR since it's very specific to semantic-ui : 

One other thing I had to do to make it work was to include / exclude semantic css in the `webpack.base.babel.js` file like so : 

```javascript
 {
      // Transform our own .css files with PostCSS and CSS-modules
      test: /\.css$/,
      exclude: [/node_modules/, /semantic/],
      loader: options.cssLoaders,
    }, {
      test: /\.css$/,
      include: [/node_modules/, /semantic/],
      loaders: ['style-loader', 'css-loader'],
    }, 
```

Then in my app.js I imported semantic.css `import '../semantic/dist/semantic.css';`


