### PR TITLE
Add meaning of "DX". Fix #313

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
   <dd>Create components, containers, routes, selectors and sagas - and their tests - right from the CLI!</dd>
 
   <dt>Instant feedback</dt>
-  <dd>Enjoy the best DX and code your app at the speed of thought! Your saved changes to the CSS and JS are reflected instantaneously without refreshing the page. Preserve application state even when you update something in the underlying code!</dd>
+  <dd>Enjoy the best DX (Developer eXperience) and code your app at the speed of thought! Your saved changes to the CSS and JS are reflected instantaneously without refreshing the page. Preserve application state even when you update something in the underlying code!</dd>
 
   <dt>Predictable state management</dt>
   <dd>Unidirectional data flow allows for change logging and time travel debugging.</dd>


### PR DESCRIPTION
The term "DX" is used in the README, but it is not explained anywhere. This PR adds "DX (Developer eXperience)", so readers unfamiliar with the term will immediately understand its meaning.

https://github.com/mxstbr/react-boilerplate/issues/313