### PR TITLE
Adds "Linux" to line 18 of docs/general/faq.md 

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -15,7 +15,7 @@ application across computer restarts.
 This simply means that there's another process already listening on port 3000.
 The fix is to kill the process and rerun `npm start`.
 
-### OS X:
+### OS X / Linux:
 
 1. Find the process id (PID):
     ```Shell


### PR DESCRIPTION
Because the process for killing an existing server is identical in Linux and OSX, this change adds " / Linux" to the subheader in this section.

(A small change, but I felt it was worth a note.)