### PR TITLE
Update container and selectors templates 

### DIFF
--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -11,8 +11,6 @@ import select{{properCase name}} from './selectors';
 import styles from './styles.css';
 {{/if}}
 
-// Underlying component
-// named export so that it can be tested
 export class {{ properCase name }} extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
     return (
@@ -27,17 +25,12 @@ export class {{ properCase name }} extends React.Component { // eslint-disable-l
   }
 }
 
-// mapStateToProps selects parts of the state to be used by the underlying component
-// Selection is made by the default selector declared in selectors.js
 const mapStateToProps = select{{properCase name}}();
 
-// mapDispatchToProps() allows to pass dispatch store method and our own
-// handlers to the underlying component
 function mapDispatchToProps(dispatch) {
   return {
     dispatch,
   };
 }
 
-// The container (smart component) to be exported by default
 export default connect(mapStateToProps, mapDispatchToProps)({{ properCase name }});

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -6,19 +6,14 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-
-{{#if wantActionsAndReducer}}
-import { createSelector } from 'reselect';
-import {
-  select{{properCase name}},
-} from './selectors';
-{{/if}}
-
+import select{{properCase name}} from './selectors';
 {{#if wantCSS}}
 import styles from './styles.css';
 {{/if}}
 
-class {{ properCase name }} extends React.Component {
+// Underlying component
+// named export so that it can be tested
+export class {{ properCase name }} extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
     return (
       {{#if wantCSS}}
@@ -26,27 +21,23 @@ class {{ properCase name }} extends React.Component {
       {{else}}
       <div>
       {{/if}}
+      This is {{properCase name}} container !
       </div>
     );
   }
 }
 
+// mapStateToProps selects parts of the state to be used by the underlying component
+// Selection is made by the default selector declared in selectors.js
+const mapStateToProps = select{{properCase name}}();
+
+// mapDispatchToProps() allows to pass dispatch store method and our own
+// handlers to the underlying component
 function mapDispatchToProps(dispatch) {
   return {
     dispatch,
   };
 }
 
-{{#if wantActionsAndReducer}}
-export default connect(createSelector(
-  select{{properCase name}}(), ({{ camelCase name }}) => ({ {{ camelCase name }} })
-), mapDispatchToProps)({{ properCase name }});
-{{else}}
-function mapStateToProps(state) {
-  return {
-
-  };
-}
-
+// The container (smart component) to be exported by default
 export default connect(mapStateToProps, mapDispatchToProps)({{ properCase name }});
-{{/if}}

--- a/internals/generators/container/reducer.test.js.hbs
+++ b/internals/generators/container/reducer.test.js.hbs
@@ -1,8 +1,9 @@
 import expect from 'expect';
 import {{ camelCase name }}Reducer from '../reducer';
+import { fromJS } from 'immutable';
 
 describe('{{ camelCase name }}Reducer', () => {
   it('returns the initial state', () => {
-    expect({{ camelCase name }}Reducer(undefined, {})).toEqual({});
+    expect({{ camelCase name }}Reducer(undefined, {})).toEqual(fromJS({}));
   });
 });

--- a/internals/generators/container/selectors.js.hbs
+++ b/internals/generators/container/selectors.js.hbs
@@ -1,38 +1,19 @@
 import { createSelector } from 'reselect';
 
 /**
- * direct selector to the {{ camelCase name }} state domain
+ * Direct selector to the {{ camelCase name }} state domain
  */
 const select{{ properCase name }}Domain = () => state => state.get('{{ camelCase name }}');
 
 /**
- * other specific selectors
+ * Other specific selectors
  */
 
-// exemples
-//  const selectFirst = () => state => state.getIn(
-//    ['{{ camelCase name }}',
-//    'myFirstProperty']
-//   );
-//  const selectSecond = () => state => state.getIn(
-//    ['{{ camelCase name }}',
-//    'mySecondProperty']
-//  );
 
 /**
- * selector used by connect
+ * Default selector used by {{ properCase name }}
  */
 
-// exemple :
-//    export default const select{{ properCase name }} = () => state => createSelector(
-//      selectFirst(),
-//      selectSecond(),
-//      (first, second) => do Something With Those Two Selected Parts,
-//    );
-//
-// To make our app work out of the box, we return the all
-// {{ properCase name }} substate.
-// Change this to only select what the underlying component needs.
 const select{{ properCase name }} = () => createSelector(
   select{{ properCase name }}Domain(),
   (substate) => substate

--- a/internals/generators/container/selectors.js.hbs
+++ b/internals/generators/container/selectors.js.hbs
@@ -1,7 +1,44 @@
 import { createSelector } from 'reselect';
 
-const select{{ properCase name }} = () => state => state.get('{{ properCase name }}')
+/**
+ * direct selector to the {{ camelCase name }} state domain
+ */
+const select{{ properCase name }}Domain = () => state => state.get('{{ camelCase name }}');
 
+/**
+ * other specific selectors
+ */
+
+// exemples
+//  const selectFirst = () => state => state.getIn(
+//    ['{{ camelCase name }}',
+//    'myFirstProperty']
+//   );
+//  const selectSecond = () => state => state.getIn(
+//    ['{{ camelCase name }}',
+//    'mySecondProperty']
+//  );
+
+/**
+ * selector used by connect
+ */
+
+// exemple :
+//    export default const select{{ properCase name }} = () => state => createSelector(
+//      selectFirst(),
+//      selectSecond(),
+//      (first, second) => do Something With Those Two Selected Parts,
+//    );
+//
+// To make our app work out of the box, we return the all
+// {{ properCase name }} substate.
+// Change this to only select what the underlying component needs.
+const select{{ properCase name }} = () => createSelector(
+  select{{ properCase name }}Domain(),
+  (substate) => substate
+);
+
+export default select{{ properCase name }};
 export {
-  select{{ properCase name }},
+  select{{ properCase name }}Domain,
 };


### PR DESCRIPTION
Following discussion in #337, I rewrote container and selectors templates :

- added comments to explain all of these selectors, mapStateToProps stuff
- simplify code in container template to use the default selector defined in selector.js, inside connect. All selector stuff is now in selectors.js

I also fixed an issue in reducer.test.js