### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ But wait... there's more!
    *At this point you can run `$ npm start` to see the example app at `http://localhost:3000`.*
 1. Run `$ npm run clean` to delete the example app.
 
+Or you can quickly create a free development environment for this project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start React Boilerplate via `Run > Start React Boilerplate` and access your site via `Preview > 3000`.
+
 Now you're ready to rumble!
 
 ## Documentation

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your React Boilerplate project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Mailtrain via "Run > Start React Boilerplate".
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "React Boilerplate",
+  "description": "A highly scalable, offline-first foundation with the best developer experience and a focus on performance and best practices. http://reactboilerplate.com",
+  "scripts": {
+    "post-create": "echo 'npm installing -- this might take a while' && npm run setup",
+    "Start React Boilerplate": "cd ~/code/react-boilerplate && npm start"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.