### PR TITLE
Prevent duplication of sagas when re-entering routes.

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -31,7 +31,7 @@ export default function createRoutes(store) {
 
         importModules.then(([reducer, sagas, component]) => {
           injectReducer('home', reducer.default);
-          injectSagas(sagas.default);
+          injectSagas('home', sagas.default);
 
           renderRoute(component);
         });

--- a/app/store.js
+++ b/app/store.js
@@ -34,6 +34,7 @@ export default function configureStore(initialState = {}, history) {
   // Extensions
   store.runSaga = sagaMiddleware.run;
   store.asyncReducers = {}; // Async reducer registry
+  store.asyncSagas = {}; // Async saga registry
 
   // Make reducers hot reloadable, see http://mxs.is/googmo
   /* istanbul ignore next */

--- a/app/utils/hooks.js
+++ b/app/utils/hooks.js
@@ -14,7 +14,13 @@ export function injectAsyncReducer(store) {
  * Inject an asynchronously loaded saga
  */
 export function injectAsyncSagas(store) {
-  return (sagas) => sagas.map(store.runSaga);
+  const prevSagas = [];
+  return (sagas) => sagas.forEach((saga) => {
+    if (!prevSagas.includes(saga)) {
+      store.runSaga(saga);
+      prevSagas.push(saga);
+    }
+  });
 }
 
 /**

--- a/app/utils/hooks.js
+++ b/app/utils/hooks.js
@@ -11,16 +11,17 @@ export function injectAsyncReducer(store) {
 }
 
 /**
- * Inject an asynchronously loaded saga
+ * Inject an asynchronously loaded saga if it's not already started.
+ * If the saga is previously loaded it will prevent starting duplicate instances
+ * of the same saga. See http://mxs.is/googng.
  */
 export function injectAsyncSagas(store) {
-  const prevSagas = [];
-  return (sagas) => sagas.forEach((saga) => {
-    if (!prevSagas.includes(saga)) {
-      store.runSaga(saga);
-      prevSagas.push(saga);
+  return (name, sagas) => {
+    if (!store.asyncSagas[name]) {
+      store.asyncSagas[name] = sagas; // eslint-disable-line
+      sagas.forEach(store.runSaga);
     }
-  });
+  };
 }
 
 /**

--- a/app/utils/tests/hooks.test.js
+++ b/app/utils/tests/hooks.test.js
@@ -45,7 +45,7 @@ describe('hooks', () => {
       const { injectReducer, injectSagas } = getHooks(store);
 
       injectReducer('test', reducer);
-      injectSagas(sagas);
+      injectSagas('test', sagas);
 
       const actual = store.getState().get('test');
       const expected = initialState.merge({ reduced: 'yup' });
@@ -76,7 +76,7 @@ describe('hooks', () => {
       it('given a store, it should provide a function to inject a saga', () => {
         const injectSagas = injectAsyncSagas(store);
 
-        injectSagas(sagas);
+        injectSagas('test', sagas);
 
         const actual = store.getState().get('test');
         const expected = initialState.merge({ reduced: 'yup' });

--- a/docs/js/redux-saga.md
+++ b/docs/js/redux-saga.md
@@ -61,7 +61,7 @@ getComponent(nextState, cb) {
 
   importModules.then(([reducer, sagas, component]) => {
     injectReducer('home', reducer.default);
-    injectSagas(sagas.default); // Inject the saga
+    injectSagas('home', sagas.default); // Inject the saga
 
     renderRoute(component);
   });

--- a/internals/generators/route/routeWithReducer.hbs
+++ b/internals/generators/route/routeWithReducer.hbs
@@ -12,7 +12,7 @@
 
         importModules.then(([reducer, sagas, component]) => {
           injectReducer('{{ camelCase component }}', reducer.default);
-          injectSagas(sagas.default);
+          injectSagas('{{ camelCase component }}', sagas.default);
           renderRoute(component);
         });
 

--- a/internals/templates/hooks.test.js
+++ b/internals/templates/hooks.test.js
@@ -45,7 +45,7 @@ describe('hooks', () => {
       const { injectReducer, injectSagas } = getHooks(store);
 
       injectReducer('test', reducer);
-      injectSagas(sagas);
+      injectSagas('test', sagas);
 
       const actual = store.getState().get('test');
       const expected = initialState.merge({ reduced: 'yup' });
@@ -76,7 +76,7 @@ describe('hooks', () => {
       it('given a store, it should provide a function to inject a saga', () => {
         const injectSagas = injectAsyncSagas(store);
 
-        injectSagas(sagas);
+        injectSagas('test', sagas);
 
         const actual = store.getState().get('test');
         const expected = initialState.merge({ reduced: 'yup' });


### PR DESCRIPTION
Prevents the addition of duplicate sagas when returning to routes that has already been loaded. 
Fixes #384. 
I'm sure this isn't the best way to fix this bug, but it's the best I could think of at the moment. Suggestions on improving this are more than welcome.