### PR TITLE
Fix wrong command on CLI readme for pagespeed

### DIFF
--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -137,7 +137,7 @@ available on the entire world. Useful for testing on different devices in differ
 $ npm run pagespeed
 ```
 
-With the remote server running (i.e. while `$ npm run start` is running in
+With the remote server running (i.e. while `$ npm run start:prod` is running in
 another terminal session), enter this command to run Google PageSpeed Insights
 and get a performance check right in your terminal!
 
@@ -175,3 +175,4 @@ $ npm run lint:css
 ```
 
 Only lints your CSS.
+

--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -137,7 +137,7 @@ available on the entire world. Useful for testing on different devices in differ
 $ npm run pagespeed
 ```
 
-With the remote server running (i.e. while `$ npm run serve` is running in
+With the remote server running (i.e. while `$ npm run start` is running in
 another terminal session), enter this command to run Google PageSpeed Insights
 and get a performance check right in your terminal!
 


### PR DESCRIPTION
Readme should be `npm run start` instead of `npm run serve`