### PR TITLE
fix stacking of async sagas execution on url change

### DIFF
--- a/app/utils/hooks.js
+++ b/app/utils/hooks.js
@@ -1,5 +1,8 @@
 import createReducer from '../reducers';
 
+// const runnedSagas = [];
+const runnedSagas = [];
+
 /**
  * Inject an asynchronously loaded reducer
  */
@@ -14,7 +17,15 @@ export function injectAsyncReducer(store) {
  * Inject an asynchronously loaded saga
  */
 export function injectAsyncSagas(store) {
-  return (sagas) => sagas.map(store.runSaga);
+  return (sagas) => {
+    sagas.map((saga) => {
+      if (runnedSagas.indexOf(runnedSagas) === -1) {
+        runnedSagas.push(runnedSagas);
+        return store.runSaga(saga);
+      }
+      return false;
+    });
+  };
 }
 
 /**


### PR DESCRIPTION
I had a problem when Saga was lunched several times if you navigate through the app and return to container with saga who would send request to server.

So basically my request ran as many times as i entered this specific url and its saga was passed to injectAsyncSagas.
