### PR TITLE
Fix selectors generator to not show an error message by default

### DIFF
--- a/internals/generators/container/selectors.js.hbs
+++ b/internals/generators/container/selectors.js.hbs
@@ -16,7 +16,7 @@ const select{{ properCase name }}Domain = () => state => state.get('{{ camelCase
 
 const select{{ properCase name }} = () => createSelector(
   select{{ properCase name }}Domain(),
-  (substate) => substate
+  (substate) => substate.toJS()
 );
 
 export default select{{ properCase name }};


### PR DESCRIPTION
Related to this issue: https://github.com/mxstbr/react-boilerplate/issues/337