### PR TITLE
Fix HMR for sync reducers

### DIFF
--- a/app/store.js
+++ b/app/store.js
@@ -39,8 +39,12 @@ export default function configureStore(initialState = {}, history) {
   /* istanbul ignore next */
   if (module.hot) {
     module.hot.accept('./reducers', () => {
-      const nextRootReducer = require('./reducers').default; // eslint-disable-line global-require
-      store.replaceReducer(nextRootReducer);
+      System.import('./reducers').then((reducerModule) => {
+        const createReducers = reducerModule.default;
+        const nextReducers = createReducers(store.asyncReducers);
+
+        store.replaceReducer(nextReducers);
+      });
     });
   }
 

--- a/internals/templates/store.js
+++ b/internals/templates/store.js
@@ -37,9 +37,11 @@ export default function configureStore(initialState = {}, history) {
   // Make reducers hot reloadable, see http://mxs.is/googmo
   /* istanbul ignore next */
   if (module.hot) {
-    module.hot.accept('./reducers', () => {
-      const nextRootReducer = require('./reducers').default; // eslint-disable-line global-require
-      store.replaceReducer(nextRootReducer);
+    System.import('./reducers').then((reducerModule) => {
+      const createReducers = reducerModule.default;
+      const nextReducers = createReducers(store.asyncReducers);
+
+      store.replaceReducer(nextReducers);
     });
   }
 


### PR DESCRIPTION
regarding #379 - 

- fixes issue pointed out by @saschatimme
- switches from legacy require.ensure to system loader

however i was not able to get this working with async reducers (yet)... i have several projects working with vanilla webpack HMR (and async reducers), but they not using react-transform or webpack v2

basically, with async imports the dependency graph requires instrumenting module.hot at the root to accept routes.js to rebuild... as @tsm91 pointed out in his console log:

```
[HMR] Updated modules:
[HMR]  - ./app/containers/HomePage/reducer.js
[HMR]  - ./app/routes.js
[HMR]  - ./app/app.js    <--- needs to capture update and re-render routes
```

can be resolved using vanilla hmr, but local component state will be lost on reloads. this also might be solved with react-hot-loader v3, but requires more investigation.