### PR TITLE
Update to more performant source mapping

### DIFF
--- a/internals/webpack/webpack.dev.babel.js
+++ b/internals/webpack/webpack.dev.babel.js
@@ -55,5 +55,5 @@ module.exports = require('./webpack.base.babel')({
   },
 
   // Emit a source map for easier debugging
-  devtool: 'inline-source-map',
+  devtool: 'cheap-module-eval-source-map',
 });


### PR DESCRIPTION
rationale: since inline-source-map generates 1:1 line-column mappings it is much more expensive to generate... dev mode can use cheap-module-eval-source-map algorithm as it provides huge performance gains by only mapping the line numbers from original source

@mxstbr this change has been removed from intl PR :)