### PR TITLE
npm script to check the npm version before install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
     "type": "git",
     "url": "git://github.com/mxstbr/react-boilerplate.git"
   },
+  "engines" : {
+    "npm" : ">=3"
+  },
   "author": "Max Stoiber",
   "license": "MIT",
   "scripts": {
+    "checknpmversion": "npm -v | cut -c 1 | awk '{print $1\"<=3\"}' | bc -l | if $1 > 0; then echo '[ERROR: React Boilerplate] You need npm version @>=3\n' && false; fi",
+    "preinstall": "npm run checknpmversion",
     "prebuild": "npm run test && npm run build:clean",
     "build:clean": "rimraf ./build/*",
     "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Max Stoiber",
   "license": "MIT",
   "scripts": {
-    "checknpmversion": "npm -v | cut -c 1 | awk '{print $1\"<=3\"}' | bc -l | if $1 > 0; then echo '[ERROR: React Boilerplate] You need npm version @>=3\n' && false; fi",
+    "checknpmversion": "npm -v | cut -c 1 | awk '{print $1\"<3\"}' | bc -l | if $1 > 0; then echo '[ERROR: React Boilerplate] You need npm version @>=3\n' && false; fi",
     "preinstall": "npm run checknpmversion",
     "prebuild": "npm run test && npm run build:clean",
     "build:clean": "rimraf ./build/*",


### PR DESCRIPTION
If the npm version is lower to 3, then `npm install` doesn't start and show an error that says:
`[ERROR: React Boilerplate] You need npm version @>=3`

Otherwise if the version is major or equal to 3 `npm install` executes