### PR TITLE
Don't let Webpack spam the terminal on errors

### DIFF
--- a/server/middlewares/frontendMiddleware.js
+++ b/server/middlewares/frontendMiddleware.js
@@ -12,6 +12,7 @@ const addDevMiddlewares = (app, options) => {
     noInfo: true,
     publicPath: options.output.publicPath,
     silent: true,
+    stats: 'errors-only',
   });
 
   app.use(middleware);


### PR DESCRIPTION
When there's an error in development such as an invalid import, Webpack likes to spam the terminal with a bunch of (as far as I can tell) useless stuff:

![](http://i.imgur.com/AKZmNR0.jpg)

This pull request causes the useless spam to be excluded.