### PR TITLE
Move pages created with clean script to containers

### DIFF
--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -27,11 +27,11 @@ rm('-rf', 'app/components/*');
 // Cleanup containers folder
 rm('-rf', 'app/containers/*');
 mkdir('app/containers/App');
-mkdir('app/components/NotFoundPage');
-mkdir('app/components/HomePage');
+mkdir('app/containers/NotFoundPage');
+mkdir('app/containers/HomePage');
 cp('internals/templates/appContainer.js', 'app/containers/App/index.js');
-cp('internals/templates/notFoundPage.js', 'app/components/NotFoundPage/index.js');
-cp('internals/templates/homePage.js', 'app/components/HomePage/index.js');
+cp('internals/templates/notFoundPage.js', 'app/containers/NotFoundPage/index.js');
+cp('internals/templates/homePage.js', 'app/containers/HomePage/index.js');
 
 // Copy selectors
 mkdir('app/containers/App/tests');

--- a/internals/templates/routes.js
+++ b/internals/templates/routes.js
@@ -22,7 +22,7 @@ export default function createRoutes() {
       name: 'home',
       getComponent(nextState, cb) {
         const importModules = Promise.all([
-          System.import('components/HomePage'),
+          System.import('containers/HomePage'),
         ]);
 
         const renderRoute = loadModule(cb);
@@ -37,7 +37,7 @@ export default function createRoutes() {
       path: '*',
       name: 'notfound',
       getComponent(nextState, cb) {
-        System.import('components/NotFoundPage')
+        System.import('containers/NotFoundPage')
           .then(loadModule(cb))
           .catch(errorLoading);
       },


### PR DESCRIPTION
Trivial edit, pages exist as containers prior to running `clean`

The changes are as follows:

* Copy from `templates/` to `containers/` when running `clean` for:
  * HomePage/
  * NotFoundPage/

* Edit to internals/templates/routes.js to import Pages from containers/