### PR TITLE
Undo commit 80da0c5 which caused npm run clean to fail

### DIFF
--- a/internals/scripts/setup.js
+++ b/internals/scripts/setup.js
@@ -38,16 +38,8 @@ cleanRepo(dir, function () {
       process.stdout.write('Initialising new repository');
       initGit(dir, function () {
         clearInterval(interval);
-
-        process.stdout.write('\n');
-        interval = animateProgress('Initialising pre-commit');
-        process.stdout.write('Initialising pre-commit');
-        installPreCommit(function () {
-          clearInterval(interval);
-
-          process.stdout.write('\nDone!');
-          process.exit(0);
-        });
+        process.stdout.write('\nDone!');
+        process.exit(0);
       });
     });
   });
@@ -65,13 +57,6 @@ function cleanRepo(dir, callback) {
  */
 function initGit(dir, callback) {
   exec('git init && git add . && git commit -m "Initial commit"', addCheckMark.bind(null, callback));
-}
-
-/**
- * Install pre-commit, needed because we have just deleted the old git repository
- */
-function installPreCommit(callback) {
-  exec('npm install pre-commit', addCheckMark.bind(null, callback));
 }
 
 /**


### PR DESCRIPTION
Following commit 80da0c5, npm run clean fails on new clones. This PR reverts those changes so that new users can install the project acceptably. The issue is discussed here https://github.com/mxstbr/react-boilerplate/issues/433
