### PR TITLE
Fix code splitting

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,9 +5,6 @@
  * code.
  */
 
-// Needed for redux-saga es6 generator support
-import 'babel-polyfill';
-
 // Load the favicon, the manifest.json file and the .htaccess file
 import 'file?name=[name].[ext]!./favicon.ico';
 import 'file?name=[name].[ext]!./manifest.json';

--- a/app/vendor.js
+++ b/app/vendor.js
@@ -1,0 +1,22 @@
+// For vendors (f.e Lodash) just import them here unless
+// you plan on chunking vendor files for async loading. You would need to import the
+// async loaded vendors at the entry point of the async loaded file.
+
+// Polyfills
+import 'babel-polyfill';
+import 'whatwg-fetch';
+
+// Vendor
+import 'history';
+import 'immutable';
+import 'react';
+import 'react-dom';
+import 'react-pure-render';
+import 'react-redux';
+import 'react-router';
+import 'react-router-redux';
+import 'react-router-scroll';
+import 'redux';
+import 'redux-immutable';
+import 'redux-saga';
+import 'reselect';

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -46,12 +46,6 @@ module.exports = (options) => ({
     }],
   },
   plugins: options.plugins.concat([
-    new webpack.optimize.CommonsChunkPlugin('common.js'),
-    new webpack.ProvidePlugin({
-      // make fetch available
-      fetch: 'exports?self.fetch!whatwg-fetch',
-    }),
-
     // Always expose NODE_ENV to webpack, in order to use `process.env.NODE_ENV`
     // inside your code for any environment checks; UglifyJS will automatically
     // drop any unreachable code.

--- a/internals/webpack/webpack.dev.babel.js
+++ b/internals/webpack/webpack.dev.babel.js
@@ -18,8 +18,8 @@ module.exports = require('./webpack.base.babel')({
     app: [
       'eventsource-polyfill', // Necessary for hot reloading with IE
       'webpack-hot-middleware/client',
-      path.join(process.cwd(), 'app/app.js') // Start with js/app.js
-    ]
+      path.join(process.cwd(), 'app/app.js'), // Start with js/app.js
+    ],
   },
 
   // Don't use hashes in dev mode for better performance
@@ -44,7 +44,12 @@ module.exports = require('./webpack.base.babel')({
 
   // Add hot reloading
   plugins: [
-    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.js' }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'app',
+      children: true,
+      async: true,
+      minChunks: 3,
+    }),
     new webpack.HotModuleReplacementPlugin(), // Tell webpack we want hot reloading
     new webpack.NoErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/internals/webpack/webpack.dev.babel.js
+++ b/internals/webpack/webpack.dev.babel.js
@@ -13,11 +13,14 @@ const postcssReporter = require('postcss-reporter');
 
 module.exports = require('./webpack.base.babel')({
   // Add hot reloading in development
-  entry: [
-    'eventsource-polyfill', // Necessary for hot reloading with IE
-    'webpack-hot-middleware/client',
-    path.join(process.cwd(), 'app/app.js'), // Start with js/app.js
-  ],
+  entry: {
+    vendor: path.join(process.cwd(), 'app/vendor.js'),
+    app: [
+      'eventsource-polyfill', // Necessary for hot reloading with IE
+      'webpack-hot-middleware/client',
+      path.join(process.cwd(), 'app/app.js') // Start with js/app.js
+    ]
+  },
 
   // Don't use hashes in dev mode for better performance
   output: {
@@ -41,6 +44,7 @@ module.exports = require('./webpack.base.babel')({
 
   // Add hot reloading
   plugins: [
+    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.js' }),
     new webpack.HotModuleReplacementPlugin(), // Tell webpack we want hot reloading
     new webpack.NoErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/internals/webpack/webpack.dev.babel.js
+++ b/internals/webpack/webpack.dev.babel.js
@@ -44,12 +44,6 @@ module.exports = require('./webpack.base.babel')({
 
   // Add hot reloading
   plugins: [
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'app',
-      children: true,
-      async: true,
-      minChunks: 3,
-    }),
     new webpack.HotModuleReplacementPlugin(), // Tell webpack we want hot reloading
     new webpack.NoErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -12,9 +12,10 @@ const postcssReporter = require('postcss-reporter');
 
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
-  entry: [
-    path.join(process.cwd(), 'app/app.js'),
-  ],
+  entry: {
+    vendor: path.join(process.cwd(), 'app/vendor.js'),
+    app: path.join(process.cwd(), 'app/app.js')
+  },
 
   // Utilize long-term caching by adding content hashes (not compilation hashes) to compiled assets
   output: {
@@ -40,6 +41,7 @@ module.exports = require('./webpack.base.babel')({
     }),
   ],
   plugins: [
+    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.[chunkhash].js' }),
 
     // OccurrenceOrderPlugin is needed for long-term caching to work properly.
     // See http://mxs.is/googmv

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -14,7 +14,7 @@ module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
   entry: {
     vendor: path.join(process.cwd(), 'app/vendor.js'),
-    app: path.join(process.cwd(), 'app/app.js')
+    app: path.join(process.cwd(), 'app/app.js'),
   },
 
   // Utilize long-term caching by adding content hashes (not compilation hashes) to compiled assets
@@ -41,7 +41,12 @@ module.exports = require('./webpack.base.babel')({
     }),
   ],
   plugins: [
-    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.[chunkhash].js' }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'app',
+      children: true,
+      async: true,
+      minChunks: 3,
+    }),
 
     // OccurrenceOrderPlugin is needed for long-term caching to work properly.
     // See http://mxs.is/googmv


### PR DESCRIPTION
What it does?

Fixes code splitting of shared vendor dependencies.

file sizes before in dev environment:

```
main.js - 4.0MB
common.js.js - 23.6KB
0.chunk.js -  619KB
1.chunk.js - 518KB
2.chunk.js - 80.5KB
4.chunk.js - 5.3KB
```

file sizes after in dev environment:
```
vendor.js - 3.7MB
app.js - 375KB (main.js)
1.chunk.js -  614KB
2.chunk.js - 518KB
4.chunk.js - 19KB
5.chunk.js - 5.3KB
```



Why this still sucks? If you inspect the chunks and search for unique patterns, for example `props.handleRoute` from `components/Buttons/index.js` you will see the CommonChunks plugin didn't extract this. (This is also an issue with the current solution.)

What i think we should do to make code splitting work is to create another file container (f.e.: common.js) and put all shared codebase related stuff there like this:

```
// Shared Components
import 'components/A';
import 'components/Button';
import 'components/Footer';
import 'components/H1';
import 'components/H2';
import 'components/H3';
import 'components/Img';
import 'components/LoadingIndicator';
```

Pros:
 * this way the chunk size will be very small

Cons:
 * the browser needs to download this file whenever a shared component gets modified (This is also an issue now with chunks, because if the `Button` component gets modified all chunks will change. So it wouldn't say this is a very big problem)


cc @mxstbr 