### PR TITLE
Added FAQ for using local webfonts in development mode.

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -56,6 +56,14 @@ The fix is to kill the process and rerun `npm start`.
     > e.g. given the output from the example above, `YOUR_PID` is `28344`, hence
     that would mean you would run `taskkill /F /PID 28344`
 
+## Local webfonts not working for development
+
+In development mode CSS sourcemaps require that styling is loaded by blob://,
+resulting in browsers resolving font files relative to the main document.
+
+A way to use local webfonts in development mode is to add an absolute
+output.publicPath in webpack.dev.babel.js, with protocol. e.g 'http://127.0.0.1:3000/'
+
 ## Have another question?
 
 Submit an [issue](https://github.com/mxstbr/react-boilerplate/issues),

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -62,7 +62,16 @@ In development mode CSS sourcemaps require that styling is loaded by blob://,
 resulting in browsers resolving font files relative to the main document.
 
 A way to use local webfonts in development mode is to add an absolute
-output.publicPath in webpack.dev.babel.js, with protocol. e.g 'http://127.0.0.1:3000/'
+output.publicPath in webpack.dev.babel.js, with protocol.
+
+```javascript
+// webpack.dev.babel.js
+
+output: {
+  publicPath: 'http://127.0.0.1:3000',
+  /* … */
+},
+```
 
 ## Have another question?
 


### PR DESCRIPTION
Defining font-faces in App/styles.css imports fonts into webpack but somehow the fonts cannot load properly in development, they work fine however when you build it.

Solution is to add an absolute output.publicPath in webpack.dev.babel.js, with protocol. i.e 'http://127.0.0.1:3000/'

#443 