### PR TITLE
Remove prefixed CSS from our source code.

### DIFF
--- a/app/containers/App/styles.css
+++ b/app/containers/App/styles.css
@@ -23,8 +23,6 @@ body.fontLoaded {
 .wrapper {
   max-width: calc(768px + 16px * 2);
   margin: 0 auto;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-height: 100%;
   padding: 0 16px;


### PR DESCRIPTION
Since we use cssnext [1], we don't need to write these prefixes
ourselves. Cssnext includes autoprefixer [2], which will automatically
add the necessary prefixes.

[1] http://cssnext.io/
[2] http://cssnext.io/features/#automatic-vendor-prefixes