### PR TITLE
Hide Webpack terminal spam on test errors

### DIFF
--- a/internals/testing/karma.conf.js
+++ b/internals/testing/karma.conf.js
@@ -31,6 +31,7 @@ module.exports = (config) => {
     // make Webpack bundle generation quiet
     webpackMiddleware: {
       noInfo: true,
+      stats: 'errors-only',
     },
 
     customLaunchers: {


### PR DESCRIPTION
Does the same as #414, but for tests.