### PR TITLE
changing default port number from cmd arguments

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ app.use(frontend(webpackConfig));
 
 // get the intended port number, use port 3000 if not provided
 const intendedPort = process.argv[3] || 3000;
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || intendedPort;
 
 // Start your app.
 app.listen(port, (err) => {

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,8 @@ const webpackConfig = isDev
 
 app.use(frontend(webpackConfig));
 
+// get the intended port number, use port 3000 if not provided
+const intendedPort = process.argv[3] || 3000;
 const port = process.env.PORT || 3000;
 
 // Start your app.


### PR DESCRIPTION
To run the app on a custom port number (e.g. 5000), execute:
npm start -- -p 5000