### PR TITLE
In dev mode All request matching is not required #524

### DIFF
--- a/server/middlewares/frontendMiddleware.js
+++ b/server/middlewares/frontendMiddleware.js
@@ -17,20 +17,6 @@ const addDevMiddlewares = (app, options) => {
 
   app.use(middleware);
   app.use(webpackHotMiddleware(compiler));
-
-  // Since webpackDevMiddleware uses memory-fs internally to store build
-  // artifacts, we use it instead
-  const fs = middleware.fileSystem;
-
-  app.get('*', (req, res) => {
-    fs.readFile(path.join(compiler.outputPath, 'index.html'), (file, error) => {
-      if (error) {
-        res.sendStatus(404);
-      } else {
-        res.send(file.toString());
-      }
-    });
-  });
 };
 
 // Production middlewares


### PR DESCRIPTION
In dev mode we are using webpackMiddleware , and webpackHotMiddleware , so they take care of serving us the App, and hot reloading . Generic request matcher is not required . This is effectively dead code and App should work as is without it.