### PR TITLE
Rename `common.js` to `common` since CommonsChunkPlugin auto-appends `.js`

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -52,7 +52,7 @@ module.exports = (options) => ({
     }],
   },
   plugins: options.plugins.concat([
-    new webpack.optimize.CommonsChunkPlugin('common.js'),
+    new webpack.optimize.CommonsChunkPlugin('common'),
     new webpack.ProvidePlugin({
       // make fetch available
       fetch: 'exports?self.fetch!whatwg-fetch',


### PR DESCRIPTION
A small fix that simply ensures webpack's CommonsChunkPlugin to generate a `common.js` bundle instead of `common.js.js`.