### PR TITLE
Allow use of Mocha grep option

### DIFF
--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -94,7 +94,14 @@ $ npm run test
 ```
 
 Tests your application with the unit tests specified in the `*test.js` files
-throughout the application.
+throughout the application.  
+All the `test` commands allow an optional `-- --grep string` argument to filter
+the tests ran by Karma. Useful if you need to run a specific test only.
+
+```Shell
+# Run only the Button component tests
+$ npm run test:watch -- --grep Button
+```
 
 ### Browsers
 
@@ -181,4 +188,3 @@ $ npm run lint:css
 ```
 
 Only lints your CSS.
-

--- a/internals/testing/karma.conf.js
+++ b/internals/testing/karma.conf.js
@@ -1,4 +1,5 @@
 const webpackConfig = require('../webpack/webpack.test.babel');
+const argv = require('minimist')(process.argv.slice(2));
 const path = require('path');
 
 module.exports = (config) => {
@@ -12,6 +13,12 @@ module.exports = (config) => {
 
     autoWatch: false,
     singleRun: true,
+
+    client: {
+      mocha: {
+        grep: argv.grep,
+      },
+    },
 
     files: [
       {

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "lint-staged": "^1.0.0",
+    "minimist": "^1.2.0",
     "mocha": "^2.4.5",
     "ngrok": "2.1.8",
     "null-loader": "^0.1.1",


### PR DESCRIPTION
This allows the use of `npm run test -- --grep ComponentName`