### PR TITLE
fixed links to docs in general

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,13 @@
 ## Table of Contents
 
 - [General](general)
-  - [**CLI Commands**](commands.md)
-  - [Tool Configuration](files.md)
-  - [Server Configurations](server-configs.md)
-  - [Deployment](deployment.md) *(currently Heroku specific)*
-  - [FAQ](faq.md)
-  - [Gotchas](gotchas.md)
+  - [**CLI Commands**](general/commands.md)
+  - [Tool Configuration](general/files.md)
+  - [Server Configurations](general/server-configs.md)
+  - [Deployment](general/deployment.md) *(currently Heroku specific)*
+  - [FAQ](general/faq.md)
+  - [Gotchas](general/gotchas.md)
+  - [Remove](general/remove.md)
 - [Testing](testing)
   - [Unit Testing](testing/unit-testing.md)
   - [Component Testing](testing/component-testing.md)


### PR DESCRIPTION
The documents in `general` were not linked correctly from `README.md`.