### PR TITLE
Update Redux dev-tools extension's store

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -42,6 +42,15 @@ openSansObserver.check().then(() => {
 const initialState = {};
 const store = configureStore(initialState, browserHistory);
 
+// If you use Redux devTools extension, since v2.0.1, they added an
+// `updateStore`, so any enhancers that change the store object
+// could be used with the devTools' store.
+// As this boilerplate uses Redux & Redux-Saga, the `updateStore` is needed
+// if you want to `take` actions in your Sagas, dispatched from devTools.
+if (window.devToolsExtension) {
+  window.devToolsExtension.updateStore(store);
+}
+
 // Sync history and store, as the react-router-redux reducer
 // is under the non-default key ("routing"), selectLocationState
 // must be provided for resolving how to retrieve the "route" in the state


### PR DESCRIPTION
If you use Redux devTools extension, since v2.0.1, they added an `updateStore`, so any enhancer that changes the store object could be used with the devTools' store.

As this boilerplate uses Redux and Redux-Saga, the `updateStore` is needed if you want to `take` actions in your Sagas, dispatched from devTools.

For more information, refer to the [release v2.0.1][release].
[release]: https://github.com/zalmoxisus/redux-devtools-extension/releases/tag/v2.0.1