### PR TITLE
Manifest.json formatting fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -10,7 +10,7 @@ import 'babel-polyfill';
 
 // Load the favicon, the manifest.json file and the .htaccess file
 import 'file?name=[name].[ext]!./favicon.ico';
-import 'file?name=[name].[ext]!./manifest.json';
+import '!file?name=[name].[ext]!./manifest.json';
 import 'file?name=[name].[ext]!./.htaccess';
 
 // Import all the third party stuff


### PR DESCRIPTION
Changed the loader for manifest.json from json-loader to file-loader
to prevent it being wrapped with module.exports

Used approach as described here:
https://github.com/webpack/webpack/issues/1747#issuecomment-164561113

Fixes #580