### PR TITLE
'same-origin' added to request utils

### DIFF
--- a/app/utils/request.js
+++ b/app/utils/request.js
@@ -37,8 +37,8 @@ function checkStatus(response) {
  * @return {object}           An object containing either "data" or "err"
  */
 export default function request(url, options) {
-  options.credentials = 'same-origin';
-  return fetch(url, options)
+  const decoratedOptions = { credentials: 'same-origin', ...options };
+  return fetch(url, decoratedOptions)
     .then(checkStatus)
     .then(parseJSON)
     .then((data) => ({ data }))

--- a/app/utils/request.js
+++ b/app/utils/request.js
@@ -37,6 +37,7 @@ function checkStatus(response) {
  * @return {object}           An object containing either "data" or "err"
  */
 export default function request(url, options) {
+  options.credentials = 'same-origin';
   return fetch(url, options)
     .then(checkStatus)
     .then(parseJSON)


### PR DESCRIPTION
This is more of a 'convenience' type of change. As I've lost couple hours figuring out why my session cookies weren't being set. Finally found that the issue was with  how the `whatwg-fetch` package has to be used. 

Think lot's of people might have this kind of problem if they start implementing standard session based authentication from this boilerplate.

The gist of this change: to be able to send cookies along with requests this option has to be included (https://github.com/github/fetch#sending-cookies)

Even if it's not getting merged, would be a good reference for people with same kind of problem ;)