### PR TITLE
Rename utils/hooks to asyncInjectors

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -2,7 +2,7 @@
 // They are all wrapped in the App component, which should contain the navbar etc
 // See http://blog.mxstbr.com/2016/01/react-apps-with-pages for more information
 // about the code splitting business
-import { getHooks } from './utils/hooks';
+import { getAsyncInjectors } from './utils/asyncInjectors';
 
 const errorLoading = (err) => {
   console.error('Dynamic page loading failed', err); // eslint-disable-line no-console
@@ -13,8 +13,8 @@ const loadModule = (cb) => (componentModule) => {
 };
 
 export default function createRoutes(store) {
-  // create reusable async injectors using getHooks factory
-  const { injectReducer, injectSagas } = getHooks(store);
+  // create reusable async injectors using getAsyncInjectors factory
+  const { injectReducer, injectSagas } = getAsyncInjectors(store);
 
   return [
     {

--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -20,7 +20,7 @@ export function injectAsyncSagas(store) {
 /**
  * Helper for creating injectors
  */
-export function getHooks(store) {
+export function getAsyncInjectors(store) {
   return {
     injectReducer: injectAsyncReducer(store),
     injectSagas: injectAsyncSagas(store),

--- a/app/utils/tests/asyncInjectors.test.js
+++ b/app/utils/tests/asyncInjectors.test.js
@@ -1,9 +1,9 @@
 /**
- * Test hooks
+ * Test async injectors
  */
 
 import expect from 'expect';
-import configureStore from 'store.js';
+import configureStore from '../../store';
 import { memoryHistory } from 'react-router';
 import { put } from 'redux-saga/effects';
 import { fromJS } from 'immutable';
@@ -11,8 +11,8 @@ import { fromJS } from 'immutable';
 import {
   injectAsyncReducer,
   injectAsyncSagas,
-  getHooks,
-} from 'utils/hooks';
+  getAsyncInjectors,
+} from '../asyncInjectors';
 
 // Fixtures
 
@@ -33,16 +33,16 @@ const sagas = [
   },
 ];
 
-describe('hooks', () => {
+describe('asyncInjectors', () => {
   let store;
 
-  describe('getHooks', () => {
+  describe('getAsyncInjectors', () => {
     before(() => {
       store = configureStore({}, memoryHistory);
     });
 
-    it('given a store, should return all hooks', () => {
-      const { injectReducer, injectSagas } = getHooks(store);
+    it('given a store, should return all async injectors', () => {
+      const { injectReducer, injectSagas } = getAsyncInjectors(store);
 
       injectReducer('test', reducer);
       injectSagas(sagas);

--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -43,10 +43,10 @@ cp('internals/templates/selectors.test.js',
 rm('-rf', 'app/utils');
 mkdir('app/utils');
 mkdir('app/utils/tests');
-cp('internals/templates/hooks.js',
-  'app/utils/hooks.js');
-cp('internals/templates/hooks.test.js',
-  'app/utils/tests/hooks.test.js');
+cp('internals/templates/asyncInjectors.js',
+  'app/utils/asyncInjectors.js');
+cp('internals/templates/asyncInjectors.test.js',
+  'app/utils/tests/asyncInjectors.test.js');
 
 // Replace the files in the root app/ folder
 cp('internals/templates/app.js', 'app/app.js');

--- a/internals/templates/asyncInjectors.js
+++ b/internals/templates/asyncInjectors.js
@@ -20,7 +20,7 @@ export function injectAsyncSagas(store) {
 /**
  * Helper for creating injectors
  */
-export function getHooks(store) {
+export function getAsyncInjectors(store) {
   return {
     injectReducer: injectAsyncReducer(store),
     injectSagas: injectAsyncSagas(store),

--- a/internals/templates/asyncInjectors.test.js
+++ b/internals/templates/asyncInjectors.test.js
@@ -1,9 +1,9 @@
 /**
- * Test hooks
+ * Test async injectors
  */
 
 import expect from 'expect';
-import configureStore from '../../store';
+import configureStore from 'store.js';
 import { memoryHistory } from 'react-router';
 import { put } from 'redux-saga/effects';
 import { fromJS } from 'immutable';
@@ -11,8 +11,8 @@ import { fromJS } from 'immutable';
 import {
   injectAsyncReducer,
   injectAsyncSagas,
-  getHooks,
-} from '../hooks';
+  getAsyncInjectors,
+} from 'utils/asyncInjectors';
 
 // Fixtures
 
@@ -33,16 +33,16 @@ const sagas = [
   },
 ];
 
-describe('hooks', () => {
+describe('asyncInjectors', () => {
   let store;
 
-  describe('getHooks', () => {
+  describe('getAsyncInjectors', () => {
     before(() => {
       store = configureStore({}, memoryHistory);
     });
 
-    it('given a store, should return all hooks', () => {
-      const { injectReducer, injectSagas } = getHooks(store);
+    it('given a store, should return all async injectors', () => {
+      const { injectReducer, injectSagas } = getAsyncInjectors(store);
 
       injectReducer('test', reducer);
       injectSagas(sagas);

--- a/internals/templates/routes.js
+++ b/internals/templates/routes.js
@@ -2,7 +2,7 @@
 // They are all wrapped in the App component, which should contain the navbar etc
 // See http://blog.mxstbr.com/2016/01/react-apps-with-pages for more information
 // about the code splitting business
-// import { getHooks } from 'utils/hooks';
+// import { getAsyncInjectors } from 'utils/asyncInjectors';
 
 const errorLoading = (err) => {
   console.error('Dynamic page loading failed', err); // eslint-disable-line no-console
@@ -13,8 +13,8 @@ const loadModule = (cb) => (componentModule) => {
 };
 
 export default function createRoutes() {
-  // Create reusable async injectors using getHooks factory
-  // const { injectReducer, injectSagas } = getHooks(store);
+  // Create reusable async injectors using getAsyncInjectors factory
+  // const { injectReducer, injectSagas } = getAsyncInjectors(store);
 
   return [
     {


### PR DESCRIPTION
I'm a naming freak and I don't think `hooks` say much about what are those functions and this file. So, sometime ago I've renamed it in my project, and now I'm porting it here so you guys can choose if you want to merge it.

-
BTW, thanks for the awesome project, it helped me a lot to grasp all those libraries and plugins.