### PR TITLE
Missing "!" in app.js (template) manifest import

### DIFF
--- a/internals/templates/app.js
+++ b/internals/templates/app.js
@@ -8,7 +8,7 @@ import 'babel-polyfill';
 
 // TODO constrain eslint import/no-unresolved rule to this block
 // Load the manifest.json file and the .htaccess file
-import 'file?name=[name].[ext]!./manifest.json';  // eslint-disable-line import/no-unresolved
+import '!file?name=[name].[ext]!./manifest.json';  // eslint-disable-line import/no-unresolved
 import 'file?name=[name].[ext]!./.htaccess';      // eslint-disable-line import/no-unresolved
 
 // Import all the third party stuff


### PR DESCRIPTION
Template of app.js is missing "!" when importing manifest.json - it makes manifest wrongly served and this not working after "npm start".