### PR TITLE
add trailing slash to publicPath in faq

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -68,7 +68,7 @@ output.publicPath in webpack.dev.babel.js, with protocol.
 // webpack.dev.babel.js
 
 output: {
-  publicPath: 'http://127.0.0.1:3000',
+  publicPath: 'http://127.0.0.1:3000/',
   /* … */
 },
 ```


### PR DESCRIPTION
the publicPath needs to end with a /, else the main.js file returns the content of index.html