### PR TITLE
Express proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "chalk": "1.1.3",
     "compression": "1.6.1",
     "express": "4.13.4",
+    "express-http-proxy": "^0.7.3",
     "fontfaceobserver": "1.7.1",
     "history": "3.0.0",
     "immutable": "3.8.1",

--- a/server/index.js
+++ b/server/index.js
@@ -14,10 +14,6 @@ const app = express();
 const pxhost = process.env.npm_config_pxhost || '127.0.0.1';
 const pxport = process.env.npm_config_pxport || '3000';
 
-
- console.log({ pxhost: pxhost });
- console.log({ pxport: pxport });
-
 // If you need a backend, e.g. an API, add your custom backend-specific middleware here
 // app.use('/api', myApi);
 
@@ -32,7 +28,7 @@ const port = argv.port || process.env.PORT || 3000;
 
 // Proxy requests
 app.use('/api', proxy(`${pxhost}:${pxport}/`, {
-  forwardPath: function(req, res) {
+  forwardPath: function (req, res) {
     return require('url').parse(req.url).path;
   }
 }));

--- a/server/index.js
+++ b/server/index.js
@@ -27,11 +27,7 @@ setup(app, {
 const port = argv.port || process.env.PORT || 3000;
 
 // Proxy requests
-app.use('/api', proxy(`${pxhost}:${pxport}/`, {
-  forwardPath: function (req, res) {
-    return require('url').parse(req.url).path;
-  }
-}));
+app.use('/api', proxy(`${pxhost}:${pxport}/`));
 
 // Start your app.
 app.listen(port, (err) => {

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 /* eslint consistent-return:0 */
 
 const express = require('express');
+const proxy = require('express-http-proxy');
 const logger = require('./logger');
 
 const argv = require('minimist')(process.argv.slice(2));
@@ -9,6 +10,13 @@ const isDev = process.env.NODE_ENV !== 'production';
 const ngrok = (isDev && process.env.ENABLE_TUNNEL) || argv.tunnel ? require('ngrok') : false;
 const resolve = require('path').resolve;
 const app = express();
+
+const pxhost = process.env.npm_config_pxhost || '127.0.0.1';
+const pxport = process.env.npm_config_pxport || '3000';
+
+
+ console.log({ pxhost: pxhost });
+ console.log({ pxport: pxport });
 
 // If you need a backend, e.g. an API, add your custom backend-specific middleware here
 // app.use('/api', myApi);
@@ -21,6 +29,13 @@ setup(app, {
 
 // get the intended port number, use port 3000 if not provided
 const port = argv.port || process.env.PORT || 3000;
+
+// Proxy requests
+app.use('/api', proxy(`${pxhost}:${pxport}/`, {
+  forwardPath: function(req, res) {
+    return require('url').parse(req.url).path;
+  }
+}));
 
 // Start your app.
 app.listen(port, (err) => {


### PR DESCRIPTION
Added plugin express-http-proxy for proxy requests. It helps to avoid CORS problems when fetching data from remote server. You can specify host and port this way:
npm start --pxhost=192.168.0.1 --pxport=3001

By default pxhost == 127.0.0.1, pxport == 3000