### PR TITLE
Altered injectAsyncSagas to prevent injecting duplicate sagas

### DIFF
--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -14,7 +14,14 @@ export function injectAsyncReducer(store) {
  * Inject an asynchronously loaded saga
  */
 export function injectAsyncSagas(store) {
-  return (sagas) => sagas.map(store.runSaga);
+  const prevSagas = [];
+
+  return sagas => sagas.forEach(saga => {
+    if (!prevSagas.includes(saga)) {
+      store.runSaga(saga);
+      prevSagas.push(saga);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
Duplicate sagas were being injected on Location_Change events.

Background:
This [issue](https://github.com/mxstbr/react-boilerplate/issues/384) was closed but no bug fix was submitted.  This PR implements the fix mentioned in issue 384 by @kraffslol.