### PR TITLE
add yaml loader and node exceptions to fix errors in dll building

### DIFF
--- a/internals/webpack/webpack.dll.babel.js
+++ b/internals/webpack/webpack.dll.babel.js
@@ -28,6 +28,24 @@ module.exports = {
     path: outputPath,
     library: '[name]',
   },
+  module: {
+    loaders: [
+      {
+        test: /\.json$/,
+        loader: 'json-loader',
+      },
+      {
+        test: /\.yaml$/,
+        loader: 'yaml-loader',
+      },
+    ]
+  },
+  node: {
+    console: true,
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty'
+  },
   plugins: [
     new webpack.DllPlugin({ name: '[name]', path: join(outputPath, '[name].json') }), // eslint-disable-line no-new
   ],

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "url-loader": "0.5.7",
     "webpack": "2.1.0-beta.15",
     "webpack-dev-middleware": "1.6.1",
-    "webpack-hot-middleware": "2.12.1"
+    "webpack-hot-middleware": "2.12.1",
+    "yaml-loader": "^0.3.0"
   }
 }


### PR DESCRIPTION
The node.js runtime expections and file-type loaders from the webpack.base.config are not inherited to the webpack.dll.config so they need to be redeclared. (Or possibly seperated out?) Not sure what the solve is.