### PR TITLE
chore(repo): GitHub templates for issues/pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -114,4 +114,4 @@ included in the project:
     with a clear title and description.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project
-owners to license your work under the terms of the [MIT License](LICENSE.txt).
+owners to license your work under the terms of the [MIT License](https://github.com/mxstbr/react-boilerplate/blob/master/LICENSE.txt).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,29 +1,30 @@
-**React Boilerplate**
+# React Boilerplate
 
-Thank you for contributing to our community! Before opening a new issue, you may find an answer in already closed issues:
-https://github.com/mxstbr/react-boilerplate/issues?q=is%3Aissue+is%3Aclosed
+Before opening a new issue, please take a moment to review our [**community guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md) to make the contribution process easy and effective for everyone involved.
 
 Please direct redux-saga related questions to stack overflow:
 http://stackoverflow.com/questions/tagged/redux-saga
 
-For questions related to the boilerplate, you can also find answers in our gitter chat: https://gitter.im/mxstbr/react-boilerplate
+For questions related to the boilerplate itself, you can also find answers on our gitter chat:
+https://gitter.im/mxstbr/react-boilerplate
 
-**Issue Type**
+**Before opening a new issue, you may find an answer in already closed issues**:
+https://github.com/mxstbr/react-boilerplate/issues?q=is%3Aissue+is%3Aclosed
 
-- [ ] Bug
-- [ ] Improvement
-- [ ] Feature
-- [ ] Other
+## Issue Type
 
-**Description**
+- [ ] Bug (https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md#bug-reports)
+- [ ] Feature (https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md#feature-requests)
+
+## Description
 
 (Add images if possible)
 
-**Steps to reproduce**
+## Steps to reproduce
 
 (Add link to a demo on https://jsfiddle.net or similar if possible)
 
-**Versions**
+# Versions
 
 - Node/NPM:
 - Browser:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+**React Boilerplate**
+
+Thank you for contributing to our community! Before opening a new issue, you may find an answer in already closed issues:
+https://github.com/mxstbr/react-boilerplate/issues?q=is%3Aissue+is%3Aclosed
+
+Please direct redux-saga related questions to stack overflow:
+http://stackoverflow.com/questions/tagged/redux-saga
+
+For questions related to the boilerplate, you can also find answers in our gitter chat: https://gitter.im/mxstbr/react-boilerplate
+
+**Issue Type**
+
+- [ ] Bug
+- [ ] Improvement
+- [ ] Feature
+- [ ] Other
+
+**Description**
+
+(Add images if possible)
+
+**Steps to reproduce**
+
+(Add link to a demo on https://jsfiddle.net or similar if possible)
+
+**Versions**
+
+- Node/NPM:
+- Browser:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,15 @@
 ## React Boilerplate
 
-Thank you for contributing! Please take a moment to review our [**community guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
-to make the contribution process easy and effective for everyone involved.
+Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
+to make the process easy and effective for everyone involved.
 
-**Please open an issue** before embarking on any significant pull request (e.g.
-implementing features, refactoring code, porting to a different language),
-otherwise you risk spending a lot of time working on something that the
-project's developers might not want to merge into the project.
+**Please open an issue** before embarking on any significant pull request, expecially those that
+add a new library or change existing tests, otherwise you risk spending a lot of time working
+on something that might not end up being merged into the project.
 
 Before opening a pull request, please ensure:
 
-- [ ] I have reviewed
+- [ ] You have followed our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
 - [ ] Pull request has tests (we are going for 100% coverage!)
 - [ ] Code is well-commented, linted and follows project conventions
 - [ ] Documentation is updated (if necessary)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,23 @@
-**React Boilerplate**
+## React Boilerplate
 
-Thank you for contributing to our community! Before opening a pull request, please ensure:
+Thank you for contributing! Please take a moment to review our [**community guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
+to make the contribution process easy and effective for everyone involved.
 
+**Please open an issue** before embarking on any significant pull request (e.g.
+implementing features, refactoring code, porting to a different language),
+otherwise you risk spending a lot of time working on something that the
+project's developers might not want to merge into the project.
+
+Before opening a pull request, please ensure:
+
+- [ ] I have reviewed
 - [ ] Pull request has tests (we are going for 100% coverage!)
-- [ ] Code is well commented and linted
+- [ ] Code is well-commented, linted and follows project conventions
 - [ ] Documentation is updated (if necessary)
 - [ ] Internal code generators and templates are updated (if necessary)
-- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).
+- [ ] Description explains the issue/use-case resolved and auto-closes related issues
+
+Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
+
+**IMPORTANT**: By submitting a patch, you agree to allow the project
+owners to license your work under the terms of the [MIT License](https://github.com/mxstbr/react-boilerplate/blob/master/LICENSE.txt).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**React Boilerplate**
+
+Thank you for contributing to our community! Before opening a pull request, please ensure:
+
+- [ ] Pull request has tests (we are going for 100% coverage!)
+- [ ] Code is well commented and linted
+- [ ] Documentation is updated (if necessary)
+- [ ] Internal code generators and templates are updated (if necessary)
+- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).


### PR DESCRIPTION
should make maintenance a little easier... direct library questions to stack overflow, encourage searching closed issues, remind people to update code generators in prs, write tests, etc