### PR TITLE
Assign name to reducer-less routes. Fix blank line bug.

### DIFF
--- a/internals/generators/route/index.js
+++ b/internals/generators/route/index.js
@@ -22,6 +22,11 @@ function sagasExists(comp) {
   }
 }
 
+function trimTemplateFile(template) {
+  // Loads the template file and trims the whitespace and then returns the content as a string.
+  return fs.readFileSync(`internals/generators/route/${template}`, 'utf8').replace(/\s*$/, '');
+}
+
 module.exports = {
   description: 'Add a route',
   prompts: [{
@@ -59,14 +64,14 @@ module.exports = {
         type: 'modify',
         path: '../../app/routes.js',
         pattern: /(\s{\n\s{0,}path: '\*',)/g,
-        templateFile: './route/routeWithReducer.hbs',
+        template: trimTemplateFile('routeWithReducer.hbs'),
       });
     } else {
       actions.push({
         type: 'modify',
         path: '../../app/routes.js',
         pattern: /(\s{\n\s{0,}path: '\*',)/g,
-        templateFile: './route/route.hbs',
+        template: trimTemplateFile('route.hbs'),
       });
     }
 

--- a/internals/generators/route/route.hbs
+++ b/internals/generators/route/route.hbs
@@ -1,5 +1,6 @@
  {
       path: '{{ path }}',
+      name: '{{ camelCase component }}',
       getComponent(location, cb) {
         System.import('{{{directory (properCase component)}}}')
           .then(loadModule(cb))


### PR DESCRIPTION
Fixes #765 

Added component name to a route without a reducer.
The blank lines were caused by a trailing whitespace at the end of the template file. Removing it sorted the issues with the blank lines.