### PR TITLE
Switch from isparta to babel-plugin-istanbul for coverage

### DIFF
--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -8,6 +8,6 @@ import chaiEnzyme from 'chai-enzyme';
 chai.use(chaiEnzyme());
 
 // Include all .js files under `app`, except app.js, reducers.js, routes.js and
-// store.js. This is for isparta code coverage
+// store.js. This is for istanbul code coverage
 const context = require.context('../../app', true, /^^((?!(app|reducers|routes|store)).)*\.js$/);
 context.keys().forEach(context);

--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -2,7 +2,6 @@
  * TEST WEBPACK CONFIGURATION
  */
 
-const path = require('path');
 const webpack = require('webpack');
 const modules = [
   'app',
@@ -22,12 +21,6 @@ module.exports = {
     noParse: [
       /node_modules(\\|\/)sinon/,
       /node_modules(\\|\/)acorn/,
-    ],
-    preLoaders: [
-      { test: /\.js$/,
-        loader: 'isparta',
-        include: path.resolve('app/'),
-      },
     ],
     loaders: [
       { test: /\.json$/, loader: 'json-loader' },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
           "transform-react-constant-elements",
           "transform-react-inline-elements"
         ]
+      },
+      "test": {
+        "plugins": [
+          "istanbul"
+        ]
       }
     }
   },
@@ -175,6 +180,7 @@
     "babel-core": "6.11.4",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
+    "babel-plugin-istanbul": "1.0.3",
     "babel-plugin-react-intl": "^2.1.3",
     "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-transform-react-constant-elements": "6.9.1",


### PR DESCRIPTION
This follows up #579 by replacing isparta with babel-plugin-istanbul. The advantage of this is that it reports coverage on the original pre-transpiled ES6 code *without* invisible `ignore` statements. The reports are fully accurate now which is awesome.