### PR TITLE
(docs) Remove mention of ngrok for `npm start`

### DIFF
--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -54,8 +54,7 @@ npm start
 ```
 
 Starts the development server and makes your application accessible at
-`localhost:3000`. Tunnels that server with `ngrok`, which means the website
-accessible anywhere! Changes in the application code will be hot-reloaded.
+`localhost:3000`. Changes in the application code will be hot-reloaded.
 
 ### Production
 


### PR DESCRIPTION
I believe the information about `ngrok` is incorrect (probably outdated) for `npm start`.
The way to enable tunnelling is to use `npm run start:tunnel`, as described a few sections below.