### PR TITLE
Disable AppCache generation

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -104,11 +104,7 @@ module.exports = require('./webpack.base.babel')({
       // Removes warning for about `additional` section usage
       safeToUseOptionalCaches: true,
 
-      AppCache: {
-        // Starting from offline-plugin:v3, AppCache by default caches only
-        // `main` section. This lets it use `additional` section too
-        caches: ['main', 'additional'],
-      },
+      AppCache: false,
     }),
   ],
 });


### PR DESCRIPTION
Disabling based on #450 and the fact that it’s depreciated: _https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache_

Also this would technically solve #779