### PR TITLE
racing condition when polyfill intl in old browser

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -105,11 +105,17 @@ if (module.hot) {
 
 // Chunked polyfill for browsers without Intl support
 if (!window.Intl) {
-  Promise.all([
-    System.import('intl'),
-    System.import('intl/locale-data/jsonp/en.js'),
-    System.import('intl/locale-data/jsonp/de.js'),
-  ]).then(() => render(translationMessages));
+  (new Promise((resolve) => {
+    resolve(System.import('intl'));
+  }))
+    .then(() => Promise.all([
+      System.import('intl/locale-data/jsonp/en.js'),
+      System.import('intl/locale-data/jsonp/de.js'),
+    ]))
+    .then(() => render(translationMessages))
+    .catch((err) => {
+      throw err;
+    });
 } else {
   render(translationMessages);
 }

--- a/internals/generators/language/polyfill-intl-locale.hbs
+++ b/internals/generators/language/polyfill-intl-locale.hbs
@@ -1,1 +1,1 @@
-$1    System.import('intl/locale-data/jsonp/{{language}}.js'),
+$1      System.import('intl/locale-data/jsonp/{{language}}.js'),


### PR DESCRIPTION
Old code in `Promisel.all([])` create racing condition bug when `intl` get import AFTER the others.

![image](https://cloud.githubusercontent.com/assets/2979072/17277706/994f4e20-5773-11e6-8394-6fde5c5a5117.png)

Fix it by using `Promise()` and make them to get called in order.

(p.s. i've no idea why my pull request is mess up, many commits shown, please feel free to advise how can i make it better, thank you.)