### PR TITLE
fix(webpack): webkit prefix get disappear because of uglifyjs

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -26,7 +26,7 @@ module.exports = require('./webpack.base.babel')({
   // of the CSS being in the JS and injected as a style tag
   cssLoaders: ExtractTextPlugin.extract(
     'style-loader',
-    'css-loader?modules&importLoaders=1!postcss-loader'
+    'css-loader?modules&-autoprefixer&importLoaders=1!postcss-loader'
   ),
 
   // In production, we minify our CSS with cssnano


### PR DESCRIPTION
When i set `cssnext` to support browser `Safari >= 8`
it expect to prefix `webkit` for some styles.

It's already work properly in dev environment
but not in production environment.

After reading this issue
https://github.com/postcss/autoprefixer/issues/660

it suppose to add `&-autoprefixer` in `css-loader` parameter

So, i add a pull request here.