### PR TITLE
fix(containers): Remove unnecessary param from LanguageProvider

### DIFF
--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -28,16 +28,9 @@ LanguageProvider.propTypes = {
   children: React.PropTypes.element.isRequired,
 };
 
-
 const mapStateToProps = createSelector(
   selectLocale(),
   (locale) => ({ locale })
 );
 
-function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(LanguageProvider);
+export default connect(mapStateToProps)(LanguageProvider);


### PR DESCRIPTION
removes unnecessary `mapDispatchToProps` from `LanguageProvider` container