### PR TITLE
chore(core): Use React.Children to manage opaque prop data

### DIFF
--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -15,13 +15,13 @@ function Button(props) {
 
   // Render an anchor tag
   let button = (
-    <a className={className} href={props.href} onClick={props.onClick}>{props.children}</a>
+    <a className={className} href={props.href} onClick={props.onClick}>{React.Children.toArray(props.children)}</a>
   );
 
   // If the Button has a handleRoute prop, we want to render a button
   if (props.handleRoute) {
     button = (
-      <button className={className} onClick={props.handleRoute} >{props.children}</button>
+      <button className={className} onClick={props.handleRoute} >{React.Children.toArray(props.children)}</button>
     );
   }
 

--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -6,7 +6,7 @@
  * otherwise it'll render a link with an onclick
  */
 
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Children } from 'react';
 
 import styles from './styles.css';
 
@@ -15,13 +15,17 @@ function Button(props) {
 
   // Render an anchor tag
   let button = (
-    <a className={className} href={props.href} onClick={props.onClick}>{React.Children.toArray(props.children)}</a>
+    <a className={className} href={props.href} onClick={props.onClick}>
+      {Children.toArray(props.children)}
+    </a>
   );
 
   // If the Button has a handleRoute prop, we want to render a button
   if (props.handleRoute) {
     button = (
-      <button className={className} onClick={props.handleRoute} >{React.Children.toArray(props.children)}</button>
+      <button className={className} onClick={props.handleRoute}>
+        {Children.toArray(props.children)}
+      </button>
     );
   }
 

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -32,7 +32,7 @@ function App(props) {
       <A className={styles.logoWrapper} href="https://twitter.com/mxstbr">
         <Img className={styles.logo} src={Banner} alt="react-boilerplate - Logo" />
       </A>
-      {props.children}
+      {React.Children.toArray(props.children)}
       <Footer />
     </div>
   );

--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -16,7 +16,7 @@ export class LanguageProvider extends React.Component { // eslint-disable-line r
   render() {
     return (
       <IntlProvider locale={this.props.locale} messages={this.props.messages[this.props.locale]}>
-        {this.props.children}
+        {React.Children.only(this.props.children)}
       </IntlProvider>
     );
   }

--- a/docs/testing/component-testing.md
+++ b/docs/testing/component-testing.md
@@ -29,7 +29,7 @@ function Button(props) {
   return (
     <button className="btn" onClick={props.onClick}>
       <CheckmarkIcon />
-      { props.children }
+      { React.children.only(props.children) }
     </button>
   );
 }

--- a/internals/templates/appContainer.js
+++ b/internals/templates/appContainer.js
@@ -24,7 +24,7 @@ export default class App extends React.Component { // eslint-disable-line react/
   render() {
     return (
       <div className={styles.container}>
-        {this.props.children}
+        {React.children.only(this.props.children)}
       </div>
     );
   }

--- a/internals/templates/appContainer.js
+++ b/internals/templates/appContainer.js
@@ -24,7 +24,7 @@ export default class App extends React.Component { // eslint-disable-line react/
   render() {
     return (
       <div className={styles.container}>
-        {React.children.only(this.props.children)}
+        {React.children.toArray(this.props.children)}
       </div>
     );
   }

--- a/internals/templates/languageProvider/languageProvider.js
+++ b/internals/templates/languageProvider/languageProvider.js
@@ -16,7 +16,7 @@ export class LanguageProvider extends React.Component { // eslint-disable-line r
   render() {
     return (
       <IntlProvider locale={this.props.locale} messages={this.props.messages[this.props.locale]}>
-        {this.props.children}
+        {React.children.only(this.props.children)}
       </IntlProvider>
     );
   }


### PR DESCRIPTION
Use [React.Children](https://facebook.github.io/react/docs/top-level-api.html#react.children) to manage opaque data structures passed to `props.children`