### PR TITLE
feature(tests): improve coverage

### DIFF
--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -37,14 +37,6 @@ import styles from './styles.css';
 
 export class HomePage extends React.Component {
   /**
-   * when initial state username is not null, submit the form to load repos
-   */
-  componentDidMount() {
-    if (this.props.username && this.props.username.trim().length > 0) {
-      this.props.onSubmitForm();
-    }
-  }
-  /**
    * Changes the route
    *
    * @param  {string} route The route we want to go to
@@ -148,7 +140,7 @@ function mapDispatchToProps(dispatch) {
     onChangeUsername: (evt) => dispatch(changeUsername(evt.target.value)),
     changeRoute: (url) => dispatch(push(url)),
     onSubmitForm: (evt) => {
-      if (evt !== undefined && evt.preventDefault) evt.preventDefault();
+      evt.preventDefault();
       dispatch(loadRepos());
     },
 

--- a/app/containers/LanguageProvider/tests/reducer.test.js
+++ b/app/containers/LanguageProvider/tests/reducer.test.js
@@ -1,11 +1,23 @@
 import expect from 'expect';
-import languageProviderReducer from '../reducer';
 import { fromJS } from 'immutable';
+
+import languageProviderReducer from '../reducer';
+import { CHANGE_LOCALE } from '../constants';
 
 describe('languageProviderReducer', () => {
   it('returns the initial state', () => {
     expect(languageProviderReducer(undefined, {})).toEqual(fromJS({
       locale: 'en',
+    }));
+  });
+
+  it('updates the locale', () => {
+    const action = {
+      type: CHANGE_LOCALE,
+      locale: 'de',
+    };
+    expect(languageProviderReducer(undefined, action)).toEqual(fromJS({
+      locale: 'de',
     }));
   });
 });

--- a/app/containers/LanguageProvider/tests/reducer.test.js
+++ b/app/containers/LanguageProvider/tests/reducer.test.js
@@ -6,18 +6,26 @@ import { CHANGE_LOCALE } from '../constants';
 
 describe('languageProviderReducer', () => {
   it('returns the initial state', () => {
-    expect(languageProviderReducer(undefined, {})).toEqual(fromJS({
+    const expected = languageProviderReducer(undefined, {});
+    const actual = expected.merge({
       locale: 'en',
-    }));
+    });
+
+    expect(expected).toEqual(actual);
   });
 
   it('updates the locale', () => {
-    const action = {
+    const initialState = fromJS({
+      locale: 'en',
+    });
+    const expected = languageProviderReducer(initialState, {
       type: CHANGE_LOCALE,
       locale: 'de',
-    };
-    expect(languageProviderReducer(undefined, action)).toEqual(fromJS({
+    });
+    const actual = initialState.merge({
       locale: 'de',
-    }));
+    });
+
+    expect(expected).toEqual(actual);
   });
 });

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -8,33 +8,35 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { selectLocale } from '../LanguageProvider/selectors';
 import { changeLocale } from '../LanguageProvider/actions';
-import { createStructuredSelector } from 'reselect';
+import { createSelector } from 'reselect';
 import styles from './styles.css';
 import messages from './messages';
 import Toggle from 'components/Toggle';
-export class LocaleToggle extends React.Component {
-  static propTypes = {
-    changeLocale: React.PropTypes.func,
-  }
 
-  handleToggle = (evt) => {
-    this.props.changeLocale(evt.target.value);
-  }
-
+export class LocaleToggle extends React.Component { // eslint-disable-line
   render() {
     return (
       <div className={styles.localeToggle}>
-        <Toggle
-          values={['en', 'de']}
-          messages={messages}
-          onToggle={this.handleToggle}
-        />
+        <Toggle values={['en', 'de']} messages={messages} onToggle={this.props.onLocaleToggle} />
       </div>
     );
   }
 }
 
-const mapStateToProps = createStructuredSelector({ locale: selectLocale() });
-const mapActionCreators = { changeLocale };
+LocaleToggle.propTypes = {
+  onLocaleToggle: React.PropTypes.func,
+};
 
-export default connect(mapStateToProps, mapActionCreators)(LocaleToggle);
+const mapStateToProps = createSelector(
+  selectLocale(),
+  (locale) => ({ locale })
+);
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onLocaleToggle: (evt) => dispatch(changeLocale(evt.target.value)),
+    dispatch,
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LocaleToggle);

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -8,35 +8,33 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { selectLocale } from '../LanguageProvider/selectors';
 import { changeLocale } from '../LanguageProvider/actions';
-import { createSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 import styles from './styles.css';
 import messages from './messages';
 import Toggle from 'components/Toggle';
+export class LocaleToggle extends React.Component {
+  static propTypes = {
+    changeLocale: React.PropTypes.func,
+  }
 
-export class LocaleToggle extends React.Component { // eslint-disable-line
+  handleToggle = (evt) => {
+    this.props.changeLocale(evt.target.value);
+  }
+
   render() {
     return (
       <div className={styles.localeToggle}>
-        <Toggle values={['en', 'de']} messages={messages} onToggle={this.props.onLocaleToggle} />
+        <Toggle
+          values={['en', 'de']}
+          messages={messages}
+          onToggle={this.handleToggle}
+        />
       </div>
     );
   }
 }
 
-LocaleToggle.propTypes = {
-  onLocaleToggle: React.PropTypes.func,
-};
+const mapStateToProps = createStructuredSelector({ locale: selectLocale() });
+const mapActionCreators = { changeLocale };
 
-const mapStateToProps = createSelector(
-  selectLocale(),
-  (locale) => ({ locale })
-);
-
-function mapDispatchToProps(dispatch) {
-  return {
-    onLocaleToggle: (evt) => dispatch(changeLocale(evt.target.value)),
-    dispatch,
-  };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(LocaleToggle);
+export default connect(mapStateToProps, mapActionCreators)(LocaleToggle);

--- a/app/containers/NotFoundPage/index.js
+++ b/app/containers/NotFoundPage/index.js
@@ -19,11 +19,7 @@ export function NotFound(props) {
       <H1>
         <FormattedMessage {...messages.header} />
       </H1>
-      <Button
-        handleRoute={function redirect() {
-          props.changeRoute('/');
-        }}
-      >
+      <Button handleRoute={() => props.push('/')}>
         <FormattedMessage {...messages.homeButton} />
       </Button>
     </article>
@@ -31,15 +27,8 @@ export function NotFound(props) {
 }
 
 NotFound.propTypes = {
-  changeRoute: React.PropTypes.func,
+  push: React.PropTypes.func,
 };
 
-// react-redux stuff
-function mapDispatchToProps(dispatch) {
-  return {
-    changeRoute: (url) => dispatch(push(url)),
-  };
-}
-
 // Wrap the component to inject dispatch and state into it
-export default connect(null, mapDispatchToProps)(NotFound);
+export default connect(null, { push })(NotFound);

--- a/app/containers/NotFoundPage/tests/index.test.js
+++ b/app/containers/NotFoundPage/tests/index.test.js
@@ -34,20 +34,14 @@ describe('<NotFound />', () => {
   });
 
   it('should link to "/"', () => {
-    const changeRouteSpy = expect.createSpy();
-    const onChangeRoute = (dest) => {
-      if (dest === '/') {
-        changeRouteSpy();
-      }
-    };
-
+    const onPushSpy = expect.createSpy();
     const renderedComponent = mount(
       <IntlProvider locale="en">
-        <NotFound changeRoute={onChangeRoute} />
+        <NotFound push={onPushSpy} />
       </IntlProvider>
     );
     const button = renderedComponent.find('button');
     button.simulate('click');
-    expect(changeRouteSpy).toHaveBeenCalled();
+    expect(onPushSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- add test for `CHANGE_LOCALE`
- remove unnecessary `mapDispatchToProps` for router actions in NotFoundPage

to increase coverage, we can reduce untested execution paths in components by letting `react-redux` dispatch our action creators directly, for example the `LocaleToggle` component:

```js
export class LocaleToggle extends React.Component {
  render() {
    return (
      <div className={styles.localeToggle}>
        <Toggle
          values={['en', 'de']}
          messages={messages}
          onToggle={this.props.onLocaleToggle}
        />
      </div>
    );
  }
}

LocaleToggle.propTypes = {
  onLocaleToggle: React.PropTypes.func,
};

const mapStateToProps = createSelector(
  selectLocale(),
  (locale) => ({ locale })
);

function mapDispatchToProps(dispatch) {
  return {
    onLocaleToggle: (evt) => dispatch(changeLocale(evt.target.value)),
    dispatch,
  };
}

export default connect(mapStateToProps, mapDispatchToProps)(LocaleToggle);
```

**the above component could be simplified using instance properties, RFC:**

```js
export class LocaleToggle extends React.Component {

  static propTypes = {
    onChangeLocale: React.PropTypes.func,
  }

  handleToggle = (evt) =>
    this.props.onChangeLocale(evt.target.value);

  render() {
    return (
      <div className={styles.localeToggle}>
        <Toggle
          values={['en', 'de']}
          messages={messages}
          onToggle={this.handleToggle}
        />
      </div>
    );
  }
}

const mapStateToProps = createStructuredSelector({
  locale: selectLocale(),
});

const mapActionCreators = {
  onChangeLocale: changeLocale,
};

export default connect(mapStateToProps, mapActionCreators)(LocaleToggle);
```

the above can be copy pasted into local component to see working... tests actually still pass, but remember to `import { createStructuredSelector } from 'reselect';`
