### PR TITLE
Feature/remove babel-preset-es2015-webpack

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -75,7 +75,7 @@ module.exports = (options) => ({
       '.jsx',
       '.react.js',
     ],
-    packageMains: [
+    mainFields: [
       'jsnext:main',
       'main',
     ],

--- a/package.json
+++ b/package.json
@@ -55,20 +55,13 @@
   "pre-commit": "lint:staged",
   "babel": {
     "presets": [
-      [
-        "es2015",
-        {
-          "modules": false
-        }
-      ],
+      ["es2015", { "modules": false }],
       "react",
       "stage-0"
     ],
     "env": {
       "production": {
-        "only": [
-          "app"
-        ],
+        "only": ["app"],
         "plugins": [
           "transform-react-remove-prop-types",
           "transform-react-constant-elements",
@@ -98,27 +91,15 @@
       }
     },
     "rules": {
-      "arrow-body-style": [
-        2,
-        "as-needed"
-      ],
-      "comma-dangle": [
-        2,
-        "always-multiline"
-      ],
+      "arrow-body-style": [2, "as-needed"],
+      "comma-dangle": [2, "always-multiline"],
       "import/imports-first": 0,
       "import/newline-after-import": 0,
       "import/no-extraneous-dependencies": 0,
       "import/no-named-as-default": 0,
       "import/no-unresolved": 2,
       "import/prefer-default-export": 0,
-      "indent": [
-        2,
-        2,
-        {
-          "SwitchCase": 1
-        }
-      ],
+      "indent": [2, 2, { "SwitchCase": 1 }],
       "jsx-a11y/aria-props": 2,
       "jsx-a11y/heading-has-content": 0,
       "jsx-a11y/href-no-hash": 2,
@@ -151,14 +132,9 @@
       "color-hex-case": "upper",
       "string-quotes": "single",
       "font-family-name-quotes": "always-where-recommended",
-      "selector-pseudo-class-no-unknown": [
-        true,
-        {
-          "ignorePseudoClasses": [
-            "global"
-          ]
-        }
-      ],
+      "selector-pseudo-class-no-unknown": [true, {
+        "ignorePseudoClasses": ["global"]
+      }],
       "indentation": 2
     }
   },

--- a/package.json
+++ b/package.json
@@ -55,13 +55,20 @@
   "pre-commit": "lint:staged",
   "babel": {
     "presets": [
-      "es2015-webpack",
+      [
+        "es2015",
+        {
+          "modules": false
+        }
+      ],
       "react",
       "stage-0"
     ],
     "env": {
       "production": {
-        "only": ["app"],
+        "only": [
+          "app"
+        ],
         "plugins": [
           "transform-react-remove-prop-types",
           "transform-react-constant-elements",
@@ -91,15 +98,27 @@
       }
     },
     "rules": {
-      "arrow-body-style": [2, "as-needed"],
-      "comma-dangle": [2, "always-multiline"],
+      "arrow-body-style": [
+        2,
+        "as-needed"
+      ],
+      "comma-dangle": [
+        2,
+        "always-multiline"
+      ],
       "import/imports-first": 0,
       "import/newline-after-import": 0,
       "import/no-extraneous-dependencies": 0,
       "import/no-named-as-default": 0,
       "import/no-unresolved": 2,
       "import/prefer-default-export": 0,
-      "indent": [2, 2, { "SwitchCase": 1 }],
+      "indent": [
+        2,
+        2,
+        {
+          "SwitchCase": 1
+        }
+      ],
       "jsx-a11y/aria-props": 2,
       "jsx-a11y/heading-has-content": 0,
       "jsx-a11y/href-no-hash": 2,
@@ -132,9 +151,14 @@
       "color-hex-case": "upper",
       "string-quotes": "single",
       "font-family-name-quotes": "always-where-recommended",
-      "selector-pseudo-class-no-unknown": [true, {
-        "ignorePseudoClasses": ["global"]
-      }],
+      "selector-pseudo-class-no-unknown": [
+        true,
+        {
+          "ignorePseudoClasses": [
+            "global"
+          ]
+        }
+      ],
       "indentation": 2
     }
   },
@@ -185,7 +209,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
-    "babel-core": "6.11.4",
+    "babel-core": "6.13.2",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
     "babel-plugin-react-intl": "^2.1.3",
@@ -193,8 +217,7 @@
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-inline-elements": "6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.2.9",
-    "babel-preset-es2015": "6.9.0",
-    "babel-preset-es2015-webpack": "6.4.2",
+    "babel-preset-es2015": "6.13.2",
     "babel-preset-react": "6.11.1",
     "babel-preset-react-hmre": "1.1.1",
     "babel-preset-stage-0": "6.5.0",


### PR DESCRIPTION
Since the latest release of `babel-core` and `babel-preset-2015` (6.13.2) can handle presets options.
No longer need to use `babel-preset-es2015-webpack`

Thanks goes to @zoontek on https://github.com/gajus/babel-preset-es2015-webpack/issues/14#issuecomment-237869435