### PR TITLE
Update lint-staged config to v2.x format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "coveralls": "cat ./coverage/lcov/lcov.info | coveralls"
   },
   "lint-staged": {
-    "lint:eslint": "*.js",
-    "stylelint": "*.css"
+    "*.js": "lint:eslint",
+    "*.css": "stylelint"
   },
   "pre-commit": "lint:staged",
   "babel": {


### PR DESCRIPTION
The version of lint-staged was changed from v1.x to v2.x in
commit 052b15648f758fe1d7835342d66404ee92ae2426.  The config format
for v2.x has keys and values flipped.