### PR TITLE
fixing store.test.js file duplication and test execution

### DIFF
--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -80,7 +80,7 @@ cp('internals/templates/index.html', 'app/index.html');
 cp('internals/templates/reducers.js', 'app/reducers.js');
 cp('internals/templates/routes.js', 'app/routes.js');
 cp('internals/templates/store.js', 'app/store.js');
-cp('internals/templates/store.test.js', 'app/store.test.js');
+cp('internals/templates/store.test.js', 'app/tests/store.test.js');
 
 // Remove the templates folder
 rm('-rf', 'internals/templates');

--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -7,7 +7,7 @@ import chai from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 chai.use(chaiEnzyme());
 
-// Include all .js files under `app`, except app.js, reducers.js, routes.js and
-// store.js. This is for isparta code coverage
-const context = require.context('../../app', true, /^^((?!(app|reducers|routes|store)).)*\.js$/);
+// Include all .js files under `app`, except app.js, reducers.js, and routes.js.
+// This is for isparta code coverage
+const context = require.context('../../app', true, /^^((?!(app|reducers|routes)).)*\.js$/);
 context.keys().forEach(context);


### PR DESCRIPTION
### Solving issue #631 : 

When `npm run clean` was executed, it copied `store.test.js` to `/app/store.test.js` instead of the original location in the `tests` folder. A simple path change in `clean.js` took care of it. 


### Solving issue #458 

This one is a bit tricky, and  I would love to have some input. Currently, there is a regex inside 
`test-bundler.js` that avoids coverage for `store.js`. This regex also captures the `store.test.js` file inside the tests folder. I assumed that since we have a test for the store.js file, it would also need to be included in the coverage. So, the regex was modified to remove `store`. 