### PR TITLE
fix(internal): make `rm -rf .git` work in Windows console

### DIFF
--- a/internals/scripts/setup.js
+++ b/internals/scripts/setup.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var shell = require('shelljs');
 var exec = require('child_process').exec;
 var path = require('path');
 var fs   = require('fs');
@@ -47,7 +48,8 @@ cleanRepo(dir, function () {
  * Deletes the .git folder in dir
  */
 function cleanRepo(dir, callback) {
-  exec('rm -Rf .git/', addCheckMark.bind(null, callback));
+  shell.rm('-rf', '.git/');
+  addCheckMark(callback);
 }
 
 /**


### PR DESCRIPTION
Windows' cmd and powershell do not support `rm` command, hopefully this part of the script now works in all of three major OS's. One question—`dir` argument is unused in `cleanRepo` and `initGit`, should I use it in `path.join` or delete it a altogether?