### PR TITLE
Add entry for vendor modules

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -12,9 +12,10 @@ const postcssReporter = require('postcss-reporter');
 
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
-  entry: [
-    path.join(process.cwd(), 'app/app.js'),
-  ],
+  entry: {
+    main: path.join(process.cwd(), 'app/app.js'),
+    vendor: [],
+  },
 
   // Utilize long-term caching by adding content hashes (not compilation hashes) to compiled assets
   output: {


### PR DESCRIPTION
I think it's a bit confusing to have the CommonChunksPlugin for 'vendor' without seeing anything related to it in the entry. I spent some time trying to figure out if I was missing something. I believe the code here is what the user is expected to add. Given that the vendor bundle gets created either way, I think this is a bit more explicit and helpful.