### PR TITLE
Adding support for svgs during testing

### DIFF
--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -43,7 +43,7 @@ module.exports = {
         loader: 'babel',
         exclude: [/node_modules/],
       },
-      { test: /\.jpe?g$|\.gif$|\.png$/i,
+      { test: /\.jpe?g$|\.gif$|\.png$|\.svg$/i,
         loader: 'null-loader',
       },
     ],


### PR DESCRIPTION
Right now if there is a component that imports an svg:

```
import React from 'react';

import Logo from './images/foo.svg';

export default function Header() {
  return (
    <section>
      <h1 className="foo">Foo</h1>
      <img src={Logo} alt="" />
    </section>
  );
}
```

And we want to create a test: 

```
describe('<Header />', () => {
  it('renders `h1`', () => {
    const wrapper = shallow(<Header />);
    expect(wrapper.find('.foo')).toExist();
  });
});
```

The test runner would fail on importing the svg file because the code doesn't support `.svg` extensions via `null-loader` inside the `webpack.test.js` file. Adding it to the `null-loader` solves the issue. 