### PR TITLE
fix(internal): make `rm -rf .git` work in Windows console

### DIFF
--- a/internals/scripts/setup.js
+++ b/internals/scripts/setup.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var shell = require('shelljs');
 var exec = require('child_process').exec;
 var path = require('path');
 var fs   = require('fs');
@@ -10,12 +11,11 @@ var readline = require('readline');
 process.stdin.resume();
 process.stdin.setEncoding('utf8');
 
-var dir = process.cwd();
-
 process.stdout.write('\n');
 var interval = animateProgress('Cleaning old repository');
 process.stdout.write('Cleaning old repository');
-cleanRepo(dir, function () {
+
+cleanRepo(function () {
   clearInterval(interval);
   process.stdout.write('\nInstalling dependencies... (This might take a while)');
   setTimeout(function () {
@@ -34,7 +34,7 @@ cleanRepo(dir, function () {
       process.stdout.write('\n');
       interval = animateProgress('Initialising new repository');
       process.stdout.write('Initialising new repository');
-      initGit(dir, function () {
+      initGit(function () {
         clearInterval(interval);
         process.stdout.write('\nDone!');
         process.exit(0);
@@ -46,14 +46,15 @@ cleanRepo(dir, function () {
 /**
  * Deletes the .git folder in dir
  */
-function cleanRepo(dir, callback) {
-  exec('rm -Rf .git/', addCheckMark.bind(null, callback));
+function cleanRepo(callback) {
+  shell.rm('-rf', '.git/');
+  addCheckMark(callback);
 }
 
 /**
  * Initializes git again
  */
-function initGit(dir, callback) {
+function initGit(callback) {
   exec('git init && git add . && git commit -m "Initial commit"', addCheckMark.bind(null, callback));
 }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start:production": "npm run build && npm run start:prod",
     "start:prod": "cross-env NODE_ENV=production node server",
     "pagespeed": "node ./internals/scripts/pagespeed.js",
-    "presetup": "npm i chalk",
+    "presetup": "npm i chalk shelljs",
     "setup": "node ./internals/scripts/setup.js",
     "postsetup": "npm run build:dll",
     "clean": "shjs ./internals/scripts/clean.js",


### PR DESCRIPTION
#860

If someone wants to check this command manually, please do it on a copy of your local repository because this command removes `.git` folder.