### PR TITLE
:fire: HOTFIX (maybe not but simple) null offset for `connect` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   <a href="#sponsors">
     <img src="https://opencollective.com/react-boilerplate/sponsors/badge.svg" alt="Sponsors" />
   </a>
+  <a href="http://thinkmill.com.au">
+    <img alt="Supported by Thinkmill" src="https://thinkmill.github.io/badge/heart.svg" />
+  </a>
   <!-- Gitter -->
   <a href="https://gitter.im/mxstbr/react-boilerplate">
     <img src="https://camo.githubusercontent.com/54dc79dc7da6b76b17bc8013342da9b4266d993c/68747470733a2f2f6261646765732e6769747465722e696d2f6d78737462722f72656163742d626f696c6572706c6174652e737667" alt="Gitter Chat" />

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -57,5 +57,5 @@ function mapDispatchToProps(dispatch) {
 {{#if wantActionsAndReducer}}
 export default connect(mapStateToProps, mapDispatchToProps)({{ properCase name }});
 {{else}}
-export default connect(mapDispatchToProps)({{ properCase name }});
+export default connect(null, mapDispatchToProps)({{ properCase name }});
 {{/if}}


### PR DESCRIPTION
Generator update: First arg passed into `connect` should be `null` if `mapDispatchToProps` is all that is needed

reference: https://github.com/reactjs/react-redux/blob/ea53d6fb076359a864a1d543568d951d4b3eab3d/src/components/connect.js#L35