### PR TITLE
Reduce test warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   <a href="#sponsors">
     <img src="https://opencollective.com/react-boilerplate/sponsors/badge.svg" alt="Sponsors" />
   </a>
+  <a href="http://thinkmill.com.au/?utm_source=github&utm_medium=badge&utm_campaign=react-boilerplate">
+    <img alt="Supported by Thinkmill" src="https://thinkmill.github.io/badge/heart.svg" />
+  </a>
   <!-- Gitter -->
   <a href="https://gitter.im/mxstbr/react-boilerplate">
     <img src="https://camo.githubusercontent.com/54dc79dc7da6b76b17bc8013342da9b4266d993c/68747470733a2f2f6261646765732e6769747465722e696d2f6d78737462722f72656163742d626f696c6572706c6174652e737667" alt="Gitter Chat" />

--- a/app/components/A/tests/index.test.js
+++ b/app/components/A/tests/index.test.js
@@ -8,29 +8,45 @@ import expect from 'expect';
 import { shallow } from 'enzyme';
 import React from 'react';
 
+const href = 'http://mxstbr.com/';
+const children = (<h1>Test</h1>);
+const renderComponent = (props = {}) => shallow(
+  <A href={href} {...props}>
+    {children}
+  </A>
+);
+
 describe('<A />', () => {
-  it('should render its children', () => {
-    const children = (<h1>Test</h1>);
-    const renderedComponent = shallow(
-      <A>
-        {children}
-      </A>
-    );
+  it('should render an <a> tag', () => {
+    const renderedComponent = renderComponent();
+    expect(renderedComponent.type()).toEqual('a');
+  });
+
+  it('should have an href attribute', () => {
+    const renderedComponent = renderComponent();
+    expect(renderedComponent.prop('href')).toEqual(href);
+  });
+
+  it('should have children', () => {
+    const renderedComponent = renderComponent();
     expect(renderedComponent.contains(children)).toEqual(true);
   });
 
-  it('should adopt the className', () => {
-    const renderedComponent = shallow(<A className="test" />);
-    expect(renderedComponent.find('a').hasClass('test')).toEqual(true);
+  it('should adopt a className attribute', () => {
+    const className = 'test';
+    const renderedComponent = renderComponent({ className });
+    expect(renderedComponent.find('a').hasClass(className)).toEqual(true);
   });
 
-  it('should adopt the href', () => {
-    const renderedComponent = shallow(<A href="mxstbr.com" />);
-    expect(renderedComponent.prop('href')).toEqual('mxstbr.com');
+  it('should adopt a target attribute', () => {
+    const target = '_blank';
+    const renderedComponent = renderComponent({ target });
+    expect(renderedComponent.prop('target')).toEqual(target);
   });
 
-  it('should adopt the target', () => {
-    const renderedComponent = shallow(<A target="_blank" />);
-    expect(renderedComponent.prop('target')).toEqual('_blank');
+  it('should adopt a type attribute', () => {
+    const type = 'text/html';
+    const renderedComponent = renderComponent({ type });
+    expect(renderedComponent.prop('type')).toEqual(type);
   });
 });

--- a/app/components/Button/tests/index.test.js
+++ b/app/components/Button/tests/index.test.js
@@ -8,37 +8,53 @@ import expect from 'expect';
 import { shallow } from 'enzyme';
 import React from 'react';
 
+const handleRoute = () => {};
+const href = 'http://mxstbr.com';
+const children = (<h1>Test</h1>);
+const renderComponent = (props = {}) => shallow(
+  <Button href={href} {...props}>
+    {children}
+  </Button>
+);
+
 describe('<Button />', () => {
-  it('should render its children', () => {
-    const children = (<h1>Test</h1>);
-    const renderedComponent = shallow(
-      <Button href="http://mxstbr.com">
-        {children}
-      </Button>
-    );
-    expect(renderedComponent.contains(children)).toEqual(true);
-  });
-
-  it('should adopt the className', () => {
-    const renderedComponent = shallow(<Button className="test" />);
-    expect(renderedComponent.find('a').hasClass('test')).toEqual(true);
-  });
-
   it('should render an <a> tag if no route is specified', () => {
-    const renderedComponent = shallow(<Button href="http://mxstbr.com" />);
+    const renderedComponent = renderComponent({ href });
     expect(renderedComponent.find('a').length).toEqual(1);
   });
 
   it('should render a button to change route if the handleRoute prop is specified', () => {
-    const renderedComponent = shallow(<Button handleRoute={function handler() {}} />);
-
+    const renderedComponent = renderComponent({ handleRoute });
     expect(renderedComponent.find('button').length).toEqual(1);
+  });
+
+  it('should have children', () => {
+    const renderedComponent = renderComponent();
+    expect(renderedComponent.contains(children)).toEqual(true);
   });
 
   it('should handle click events', () => {
     const onClickSpy = expect.createSpy();
-    const renderedComponent = shallow(<Button onClick={onClickSpy} />);
+    const renderedComponent = renderComponent({ onClick: onClickSpy });
     renderedComponent.find('a').simulate('click');
     expect(onClickSpy).toHaveBeenCalled();
+  });
+
+  it('should adopt a className attribute', () => {
+    const className = 'test';
+    const renderedComponent = renderComponent({ className });
+    expect(renderedComponent.find('a').hasClass(className)).toEqual(true);
+  });
+
+  it('should not adopt a type attribute when rendering an <a> tag', () => {
+    const type = 'text/html';
+    const renderedComponent = renderComponent({ href, type });
+    expect(renderedComponent.prop('type')).toNotExist();
+  });
+
+  it('should not adopt a type attribute when rendering a button', () => {
+    const type = 'submit';
+    const renderedComponent = renderComponent({ handleRoute, type });
+    expect(renderedComponent.prop('type')).toNotExist();
   });
 });

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -26,13 +26,13 @@ describe('<Img />', () => {
     expect(renderedComponent).to.have.attr('alt', alt);
   });
 
-  it('should adopt the className', () => {
+  it('should adopt a className attribute', () => {
     const className = 'test';
     const renderedComponent = renderComponent({ className });
     expect(renderedComponent).to.have.attr('class', className);
   });
 
-  it('should not adopt the srcset', () => {
+  it('should not adopt a srcset attribute', () => {
     const srcset = 'test-HD.png 2x';
     const renderedComponent = renderComponent({ srcset });
     expect(renderedComponent).to.not.have.attr('srcset', srcset);

--- a/app/components/Img/tests/index.test.js
+++ b/app/components/Img/tests/index.test.js
@@ -4,14 +4,37 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
+const src = 'test.png';
+const alt = 'test';
+const renderComponent = (props = {}) => shallow(
+  <Img src={src} alt={alt} {...props} />
+);
+
 describe('<Img />', () => {
   it('should render an <img> tag', () => {
-    const renderedComponent = shallow(<Img src="test.png" alt="test" />);
+    const renderedComponent = renderComponent();
     expect(renderedComponent).to.have.tagName('img');
   });
 
+  it('should have an src attribute', () => {
+    const renderedComponent = renderComponent();
+    expect(renderedComponent).to.have.attr('src', src);
+  });
+
   it('should have an alt attribute', () => {
-    const renderedComponent = shallow(<Img src="test.png" alt="test" />);
-    expect(renderedComponent).to.have.attr('alt', 'test');
+    const renderedComponent = renderComponent();
+    expect(renderedComponent).to.have.attr('alt', alt);
+  });
+
+  it('should adopt the className', () => {
+    const className = 'test';
+    const renderedComponent = renderComponent({ className });
+    expect(renderedComponent).to.have.attr('class', className);
+  });
+
+  it('should not adopt the srcset', () => {
+    const srcset = 'test-HD.png 2x';
+    const renderedComponent = renderComponent({ srcset });
+    expect(renderedComponent).to.not.have.attr('srcset', srcset);
   });
 });

--- a/app/containers/App/tests/index.test.js
+++ b/app/containers/App/tests/index.test.js
@@ -1,11 +1,15 @@
+import App from '../index';
+import Footer from 'components/Footer';
+
 import expect from 'expect';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import App from '../index';
-import Footer from 'components/Footer';
-
 describe('<App />', () => {
+  /* eslint no-underscore-dangle: ["error", {"allow": ["__Rewire__", "__ResetDependency__"]}] */
+  before(() => App.__Rewire__('Banner', 'test.png'));
+  after(() => App.__ResetDependency__('Banner'));
+
   it('should render the logo', () => {
     const renderedComponent = shallow(
       <App />

--- a/app/containers/App/tests/index.test.js
+++ b/app/containers/App/tests/index.test.js
@@ -6,7 +6,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 describe('<App />', () => {
-  /* eslint no-underscore-dangle: ["error", {"allow": ["__Rewire__", "__ResetDependency__"]}] */
   before(() => App.__Rewire__('Banner', 'test.png'));
   after(() => App.__ResetDependency__('Banner'));
 

--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -14,6 +14,7 @@ module.exports = {
   isparta: {
     babel: {
       presets: ['es2015', 'react', 'stage-0'],
+      plugins: ['rewire'],
     },
   },
   module: {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,13 @@
       "max-len": 0,
       "newline-per-chained-call": 0,
       "no-console": 1,
+      "no-underscore-dangle": [
+        2,
+        { "allow": [
+          "__Rewire__",
+          "__ResetDependency__"
+        ] }
+      ],
       "no-use-before-define": 0,
       "prefer-template": 2,
       "react/jsx-filename-extension": 0,

--- a/package.json
+++ b/package.json
@@ -131,10 +131,12 @@
       "no-console": 1,
       "no-underscore-dangle": [
         2,
-        { "allow": [
-          "__Rewire__",
-          "__ResetDependency__"
-        ] }
+        {
+          "allow": [
+            "__Rewire__",
+            "__ResetDependency__"
+          ]
+        }
       ],
       "no-use-before-define": 0,
       "prefer-template": 2,

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "babel-loader": "6.2.4",
     "babel-plugin-react-intl": "2.1.3",
     "babel-plugin-react-transform": "2.0.2",
+    "babel-plugin-rewire": "1.0.0-rc-6",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-react-inline-elements": "6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.2.9",


### PR DESCRIPTION
PR for #909.

Reduce test warnings by passing required propTypes to the components.

To resolve the `<App />` test warning I added `babel-plugin-rewire` to mock the `Banner` so it is a string and not an object. This involved modifying the "internals" so this may need attention.

Resolving the `... ReactComponentTreeDevtool ...` warnings was a coincidence of extending the `<Img />` test coverage. This warning has been resolved in React `15.3.1`, see [React Issue 7240](https://github.com/facebook/react/issues/7240).