### PR TITLE
Remove travis sudo (use chromium) and cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: node_js
-sudo: true
-dist: trusty
 node_js:
   - "5.0"
 script: npm run build
 before_install:
-  - export CHROME_BIN=/usr/bin/google-chrome
+  - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sudo apt-get update
-  - sudo apt-get install -y libappindicator1 fonts-liberation
-  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - sudo dpkg -i google-chrome*.deb
   - sh -e /etc/init.d/xvfb start
 notifications:
   email:
     on_failure: change
 after_success: 'npm run coveralls'
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [X] You have followed our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [X] Pull request has tests (we are going for 100% coverage!)
- [X] Code is well-commented, linted and follows project conventions
- [X] Documentation is updated (if necessary)
- [X] Internal code generators and templates are updated (if necessary)
- [X] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/mxstbr/react-boilerplate/blob/master/LICENSE.md).

@mxstbr As requested, this should speed up your Travis build significantly (by my testing, by about 30%). 

Firstly, Travis VMs come with chromium installed, so you no longer need to install chrome in `travis.yml`. This also means you no longer need `sudo`. Enabling sudo means your job can take 20-52s to boot, whereas now that'll be 1-6s as we don't use sudo. ([source](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments))

You can also cache the `node_modules` folder, which should significantly reduce the time spent on `npm install`, as in most cases all the packages will be there waiting (although post-install scripts will still run). 

You can see an example build [here](https://travis-ci.org/jstockwin/react-boilerplate-testing/builds/161364470), which took 2mins 37secs compared to your latest build which took 3mins 47secs. Note that the first build after this is merged won't be quite that quick, as there won't have been any previous builds to retrieve the `node_modules` cache from. 