### PR TITLE
Webpack 2.1.0-beta.25

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -71,20 +71,26 @@ module.exports = (options) => ({
       },
     }),
     new webpack.NamedModulesPlugin(),
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        // 'context' needed for css-loader see
+        // https://github.com/mxstbr/react-boilerplate/pull/1032#issuecomment-249821676
+        context: __dirname,
+        postcss: () => [
+          postcssFocus(), // Add a :focus to every :hover
+          cssnext({ // Allow future CSS features to be used, also auto-prefixes the CSS...
+            browsers: ['last 2 versions', 'IE > 10'], // ...based on this browser list
+          }),
+          postcssReporter({ // Posts messages from plugins to the terminal
+            clearMessages: true,
+          }),
+        ],
+      },
+    }),
   ]),
-  postcss: () => [
-    postcssFocus(), // Add a :focus to every :hover
-    cssnext({ // Allow future CSS features to be used, also auto-prefixes the CSS...
-      browsers: ['last 2 versions', 'IE > 10'], // ...based on this browser list
-    }),
-    postcssReporter({ // Posts messages from plugins to the terminal
-      clearMessages: true,
-    }),
-  ],
   resolve: {
     modules: ['app', 'node_modules'],
     extensions: [
-      '',
       '.js',
       '.jsx',
       '.react.js',
@@ -97,5 +103,4 @@ module.exports = (options) => ({
   },
   devtool: options.devtool,
   target: 'web', // Make web variables accessible to webpack, e.g. window
-  progress: true,
 });

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -32,19 +32,8 @@ module.exports = require('./webpack.base.babel')({
       async: true,
     }),
 
-    // OccurrenceOrderPlugin is needed for long-term caching to work properly.
-    // See http://mxs.is/googmv
-    new webpack.optimize.OccurrenceOrderPlugin(true),
-
     // Merge all duplicate modules
     new webpack.optimize.DedupePlugin(),
-
-    // Minify and optimize the JavaScript
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false, // ...but do not show warnings in the console (there is a lot of them)
-      },
-    }),
 
     // Minify and optimize the index.html
     new HtmlWebpackPlugin({

--- a/internals/webpack/webpack.test.babel.js
+++ b/internals/webpack/webpack.test.babel.js
@@ -68,7 +68,6 @@ module.exports = {
     'react/lib/ReactContext': 'window',
   },
   resolve: {
-    modulesDirectories: modules,
     modules,
     alias: {
       // required for enzyme to work properly

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preinstall": "npm run npmcheckversion",
     "postinstall": "npm run build:dll",
     "prebuild": "npm run build:clean && npm run test",
-    "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p",
+    "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress",
     "build:clean": "npm run test:clean && rimraf ./build",
     "build:dll": "node ./internals/scripts/dependencies.js",
     "start": "cross-env NODE_ENV=development node server",
@@ -306,7 +306,7 @@
     "stylelint": "7.4.2",
     "stylelint-config-standard": "13.0.2",
     "url-loader": "0.5.7",
-    "webpack": "2.1.0-beta.22",
+    "webpack": "2.1.0-beta.25",
     "webpack-dev-middleware": "1.8.4",
     "webpack-hot-middleware": "2.13.0"
   }


### PR DESCRIPTION
> fixes https://github.com/mxstbr/react-boilerplate/issues/1027
- ~~renamed webpack._.babel.js to webapack._.js as the .babel postfix doesn't work in webpack 2 and it doesnt seem to be used in this project anyway.~~
- ~~removed the sourcemap query from dev as webpack 2 automatically passes through to plugins when set as source-map in the dev-tool option~~
- removed prod jsUglify as this is automatically done with `-p` arg
- moved postCSS config to LoaderOptionsPlugin within webpack
