### PR TITLE
Fix/simplify footer CSS

### DIFF
--- a/app/components/Button/buttonStyles.js
+++ b/app/components/Button/buttonStyles.js
@@ -4,7 +4,6 @@ const buttonStyles = css`
   display: inline-block;
   box-sizing: border-box;
   padding: 0.25em 2em;
-  margin: 0;
   text-decoration: none;
   border-radius: 4px;
   -webkit-font-smoothing: antialiased;

--- a/app/components/Footer/index.js
+++ b/app/components/Footer/index.js
@@ -10,22 +10,18 @@ function Footer() {
   return (
     <Wrapper>
       <section>
-        <p>
-          <FormattedMessage {...messages.licenseMessage} />
-        </p>
+        <FormattedMessage {...messages.licenseMessage} />
       </section>
       <section>
         <LocaleToggle />
       </section>
       <section>
-        <p>
-          <FormattedMessage
-            {...messages.authorMessage}
-            values={{
-              author: <A href="https://twitter.com/mxstbr">Max Stoiber</A>,
-            }}
-          />
-        </p>
+        <FormattedMessage
+          {...messages.authorMessage}
+          values={{
+            author: <A href="https://twitter.com/mxstbr">Max Stoiber</A>,
+          }}
+        />
       </section>
     </Wrapper>
   );

--- a/app/components/Footer/tests/index.test.js
+++ b/app/components/Footer/tests/index.test.js
@@ -14,9 +14,7 @@ describe('<Footer />', () => {
     );
     expect(renderedComponent.contains(
       <section>
-        <p>
-          <FormattedMessage {...messages.licenseMessage} />
-        </p>
+        <FormattedMessage {...messages.licenseMessage} />
       </section>
     )).toEqual(true);
   });
@@ -25,14 +23,12 @@ describe('<Footer />', () => {
     const renderedComponent = shallow(<Footer />);
     expect(renderedComponent.contains(
       <section>
-        <p>
-          <FormattedMessage
-            {...messages.authorMessage}
-            values={{
-              author: <A href="https://twitter.com/mxstbr">Max Stoiber</A>,
-            }}
-          />
-        </p>
+        <FormattedMessage
+          {...messages.authorMessage}
+          values={{
+            author: <A href="https://twitter.com/mxstbr">Max Stoiber</A>,
+          }}
+        />
       </section>
     )).toEqual(true);
   });


### PR DESCRIPTION
- fixes a vertical alignment issue in the footer
- moves the 4em margin from the bottom to the footer margin-top
- removes unnecessary CSS

Before: 
<img width="875" alt="screen shot 2016-10-22 at 14 51 52" src="https://cloud.githubusercontent.com/assets/4217871/19619101/1de33528-9867-11e6-9df2-7107fb146f95.png">

After:
<img width="836" alt="screen shot 2016-10-05 at 10 56 13" src="https://cloud.githubusercontent.com/assets/4217871/19105438/94545e06-8aea-11e6-9fe5-09be3f9aaa16.png">
