### PR TITLE
Header nav

### DIFF
--- a/app/components/Header/HeaderLink.js
+++ b/app/components/Header/HeaderLink.js
@@ -1,0 +1,25 @@
+import { Link } from 'react-router';
+import styled from 'styled-components';
+
+export default styled(Link)`
+  display: inline-flex;
+  padding: 0.25em 2em;
+  margin: 1em;
+  text-decoration: none;
+  border-radius: 4px;
+  -webkit-font-smoothing: antialiased;
+  -webkit-touch-callout: none;
+  user-select: none;
+  cursor: pointer;
+  outline: 0;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+  border: 2px solid #41ADDD;
+  color: #41ADDD;
+  
+  &:active {
+    background: #41ADDD;
+    color: #FFF;
+  }
+`;

--- a/app/components/Header/NavBar.js
+++ b/app/components/Header/NavBar.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export default styled.div`
+  text-align: center;
+`;

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -1,15 +1,29 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import A from './A';
 import Img from './Img';
+import NavBar from './NavBar';
+import HeaderLink from './HeaderLink';
 import Banner from './banner.jpg';
+import messages from './messages';
 
 class Header extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
     return (
-      <A href="https://twitter.com/mxstbr">
-        <Img src={Banner} alt="react-boilerplate - Logo" />
-      </A>
+      <div>
+        <A href="https://twitter.com/mxstbr">
+          <Img src={Banner} alt="react-boilerplate - Logo" />
+        </A>
+        <NavBar>
+          <HeaderLink to="/">
+            <FormattedMessage {...messages.home} />
+          </HeaderLink>
+          <HeaderLink to="/features">
+            <FormattedMessage {...messages.features} />
+          </HeaderLink>
+        </NavBar>
+      </div>
     );
   }
 }

--- a/app/components/Header/messages.js
+++ b/app/components/Header/messages.js
@@ -1,0 +1,17 @@
+/*
+ * HomePage Messages
+ *
+ * This contains all the text for the HomePage component.
+ */
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  home: {
+    id: 'boilerplate.components.Header.home',
+    defaultMessage: 'Home',
+  },
+  features: {
+    id: 'boilerplate.components.Header.features',
+    defaultMessage: 'Features',
+  },
+});

--- a/app/components/Header/tests/index.test.js
+++ b/app/components/Header/tests/index.test.js
@@ -1,14 +1,14 @@
 import expect from 'expect';
-import { render } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 import Header from '../index';
 
 describe('<Header />', () => {
-  it('should render the logo', () => {
-    const renderedComponent = render(
+  it('should render a div', () => {
+    const renderedComponent = shallow(
       <Header />
     );
-    expect(renderedComponent.find('img').length).toEqual(1);
+    expect(renderedComponent.find('div').length).toEqual(1);
   });
 });

--- a/app/containers/FeaturePage/index.js
+++ b/app/containers/FeaturePage/index.js
@@ -4,23 +4,16 @@
  * List all the features
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { push } from 'react-router-redux';
 import Helmet from 'react-helmet';
 
 import messages from './messages';
 import { FormattedMessage } from 'react-intl';
-import Button from 'components/Button';
 import H1 from 'components/H1';
 import List from './List';
 import ListItem from './ListItem';
 import ListItemTitle from './ListItemTitle';
 
-export class FeaturePage extends React.Component {
-  openHomePage = () => {
-    this.props.dispatch(push('/'));
-  };
-
+export default class FeaturePage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
     return (
       <div>
@@ -79,16 +72,7 @@ export class FeaturePage extends React.Component {
             </p>
           </ListItem>
         </List>
-        <Button handleRoute={this.openHomePage}>
-          <FormattedMessage {...messages.homeButton} />
-        </Button>
       </div>
     );
   }
 }
-
-FeaturePage.propTypes = {
-  dispatch: React.PropTypes.func,
-};
-
-export default connect()(FeaturePage);

--- a/app/containers/FeaturePage/messages.js
+++ b/app/containers/FeaturePage/messages.js
@@ -92,8 +92,4 @@ export default defineMessages({
     id: 'boilerplate.containers.FeaturePage.internationalization.message',
     defaultMessage: 'Scalable apps need to support multiple languages, easily add and support multiple languages with `react-intl`.',
   },
-  homeButton: {
-    id: 'boilerplate.containers.FeaturePage.home',
-    defaultMessage: 'Home',
-  },
 });

--- a/app/containers/FeaturePage/tests/index.test.js
+++ b/app/containers/FeaturePage/tests/index.test.js
@@ -2,10 +2,9 @@ import expect from 'expect';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import Button from 'components/Button';
 import { FormattedMessage } from 'react-intl';
 import messages from '../messages';
-import { FeaturePage } from '../index';
+import FeaturePage from '../index';
 import H1 from 'components/H1';
 
 describe('<FeaturePage />', () => {
@@ -18,19 +17,5 @@ describe('<FeaturePage />', () => {
         <FormattedMessage {...messages.header} />
       </H1>
     )).toEqual(true);
-  });
-
-  it('should link to "/"', (done) => {
-    // Spy on the openRoute method of the FeaturePage
-    const dispatch = (action) => {
-      expect(action.payload.args).toEqual('/');
-      done();
-    };
-
-    const renderedComponent = shallow(
-      <FeaturePage dispatch={dispatch} />
-    );
-    const button = renderedComponent.find(Button);
-    button.prop('handleRoute')();
   });
 });

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -8,11 +8,9 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
-import { push } from 'react-router-redux';
 import { createStructuredSelector } from 'reselect';
 
 import AtPrefix from './AtPrefix';
-import Button from 'components/Button';
 import CenteredSection from './CenteredSection';
 import Form from './Form';
 import H2 from 'components/H2';
@@ -37,21 +35,6 @@ export class HomePage extends React.Component {
       this.props.onSubmitForm();
     }
   }
-  /**
-   * Changes the route
-   *
-   * @param  {string} route The route we want to go to
-   */
-  openRoute = (route) => {
-    this.props.changeRoute(route);
-  };
-
-  /**
-   * Changed route to '/features'
-   */
-  openFeaturesPage = () => {
-    this.openRoute('/features');
-  };
 
   render() {
     let mainContent = null;
@@ -110,9 +93,6 @@ export class HomePage extends React.Component {
             </Form>
             {mainContent}
           </Section>
-          <Button handleRoute={this.openFeaturesPage}>
-            <FormattedMessage {...messages.featuresButton} />
-          </Button>
         </div>
       </article>
     );
@@ -120,7 +100,6 @@ export class HomePage extends React.Component {
 }
 
 HomePage.propTypes = {
-  changeRoute: React.PropTypes.func,
   loading: React.PropTypes.bool,
   error: React.PropTypes.oneOfType([
     React.PropTypes.object,
@@ -138,13 +117,10 @@ HomePage.propTypes = {
 export function mapDispatchToProps(dispatch) {
   return {
     onChangeUsername: (evt) => dispatch(changeUsername(evt.target.value)),
-    changeRoute: (url) => dispatch(push(url)),
     onSubmitForm: (evt) => {
       if (evt !== undefined && evt.preventDefault) evt.preventDefault();
       dispatch(loadRepos());
     },
-
-    dispatch,
   };
 }
 

--- a/app/containers/HomePage/messages.js
+++ b/app/containers/HomePage/messages.js
@@ -26,8 +26,4 @@ export default defineMessages({
     id: 'boilerplate.containers.HomePage.tryme.atPrefix',
     defaultMessage: '@',
   },
-  featuresButton: {
-    id: 'boilerplate.containers.HomePage.features.Button',
-    defaultMessage: 'Features',
-  },
 });

--- a/app/containers/HomePage/tests/index.test.js
+++ b/app/containers/HomePage/tests/index.test.js
@@ -10,7 +10,6 @@ import { IntlProvider } from 'react-intl';
 import { HomePage, mapDispatchToProps } from '../index';
 import { changeUsername } from '../actions';
 import { loadRepos } from '../../App/actions';
-import { push } from 'react-router-redux';
 import RepoListItem from 'containers/RepoListItem';
 import List from 'components/List';
 import LoadingIndicator from 'components/LoadingIndicator';
@@ -73,26 +72,6 @@ describe('<HomePage />', () => {
     expect(renderedComponent.contains(<List items={repos} component={RepoListItem} />)).toEqual(true);
   });
 
-  it('should link to /features', () => {
-    const openRouteSpy = expect.createSpy();
-
-    // Spy on the openRoute method of the HomePage
-    const openRoute = (dest) => {
-      if (dest === '/features') {
-        openRouteSpy();
-      }
-    };
-
-    const renderedComponent = mount(
-      <IntlProvider locale="en">
-        <HomePage loading changeRoute={openRoute} />
-      </IntlProvider>
-    );
-    const button = renderedComponent.find('button');
-    button.simulate('click');
-    expect(openRouteSpy).toHaveBeenCalled();
-  });
-
   describe('mapDispatchToProps', () => {
     describe('onChangeUsername', () => {
       it('should be injected', () => {
@@ -108,22 +87,6 @@ describe('<HomePage />', () => {
         result.onChangeUsername({ target: { value: username } });
         expect(dispatch).toHaveBeenCalledWith(changeUsername(username));
       });
-    });
-  });
-
-  describe('changeRoute', () => {
-    it('should be injected', () => {
-      const dispatch = expect.createSpy();
-      const result = mapDispatchToProps(dispatch);
-      expect(result.changeRoute).toExist();
-    });
-
-    it('should dispatch push when called', () => {
-      const dispatch = expect.createSpy();
-      const result = mapDispatchToProps(dispatch);
-      const route = '/';
-      result.changeRoute(route);
-      expect(dispatch).toHaveBeenCalledWith(push(route));
     });
   });
 

--- a/app/containers/NotFoundPage/index.js
+++ b/app/containers/NotFoundPage/index.js
@@ -5,34 +5,17 @@
  */
 
 import React from 'react';
-import { connect } from 'react-redux';
-import { push } from 'react-router-redux';
 
 import messages from './messages';
 import { FormattedMessage } from 'react-intl';
-import Button from 'components/Button';
 import H1 from 'components/H1';
 
-export function NotFound(props) {
+export default function NotFound() {
   return (
     <article>
       <H1>
         <FormattedMessage {...messages.header} />
       </H1>
-      <Button
-        handleRoute={function redirect() {
-          props.dispatch(push('/'));
-        }}
-      >
-        <FormattedMessage {...messages.homeButton} />
-      </Button>
     </article>
   );
 }
-
-NotFound.propTypes = {
-  dispatch: React.PropTypes.func,
-};
-
-// Wrap the component to inject dispatch and state into it
-export default connect()(NotFound);

--- a/app/containers/NotFoundPage/messages.js
+++ b/app/containers/NotFoundPage/messages.js
@@ -10,8 +10,4 @@ export default defineMessages({
     id: 'boilerplate.containers.NotFoundPage.header',
     defaultMessage: 'Page not found.',
   },
-  homeButton: {
-    id: 'boilerplate.containers.NotFoundPage.home',
-    defaultMessage: 'Home',
-  },
 });

--- a/app/containers/NotFoundPage/tests/index.test.js
+++ b/app/containers/NotFoundPage/tests/index.test.js
@@ -7,9 +7,8 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { FormattedMessage } from 'react-intl';
-import { NotFound } from '../index';
+import NotFound from '../index';
 import H1 from 'components/H1';
-import Button from 'components/Button';
 
 describe('<NotFound />', () => {
   it('should render the Page Not Found text', () => {
@@ -23,26 +22,5 @@ describe('<NotFound />', () => {
           defaultMessage={'Page not found.'}
         />
       </H1>)).toEqual(true);
-  });
-
-  it('should render a button', () => {
-    const renderedComponent = shallow(
-      <NotFound />
-    );
-    const renderedButton = renderedComponent.find(Button);
-    expect(renderedButton.length).toEqual(1);
-  });
-
-  it('should link to "/"', (done) => {
-    const dispatch = (action) => {
-      expect(action.payload.args).toEqual('/');
-      done();
-    };
-
-    const renderedComponent = shallow(
-      <NotFound dispatch={dispatch} />
-    );
-    const button = renderedComponent.find(Button);
-    button.prop('handleRoute')();
   });
 });

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -3,12 +3,13 @@
   "app.components.LocaleToggle.en": "",
   "boilerplate.components.Footer.author.message": "Mit Liebe gemacht von {author}.",
   "boilerplate.components.Footer.license.message": "Dieses Projekt wird unter der MIT-Lizenz veröffentlicht.",
+  "boilerplate.components.Header.home": "",
+  "boilerplate.containers.Header.features": "",
   "boilerplate.containers.FeaturePage.css.header": "",
   "boilerplate.containers.FeaturePage.css.message": "Die nächste Generation von CSS",
   "boilerplate.containers.FeaturePage.feedback.header": "Sofortiges Feedback",
   "boilerplate.containers.FeaturePage.feedback.message": "Genießen Sie die beste Entwicklungserfahrung und programmieren Sie Ihre App so schnell wie noch nie! Ihre Änderungen an dem CSS und JavaScript sind sofort reflektiert, ohne die Seite aktualisieren zu müssen. So bleibt der Anwendungszustand bestehen, auch wenn Sie etwas in dem darunter liegenden Code aktualisieren!",
   "boilerplate.containers.FeaturePage.header": "",
-  "boilerplate.containers.FeaturePage.home": "",
   "boilerplate.containers.FeaturePage.internationalization.header": "Komplette i18n Standard-Internationalisierung und Pluralisierung",
   "boilerplate.containers.FeaturePage.internationalization.message": "Das Internet ist global. Mehrsprachige- und Pluralisierungsunterstützung ist entscheidend für große Web-Anwendungen.",
   "boilerplate.containers.FeaturePage.javascript.header": "Das Internet ist global. Mehrsprachige- und Pluralisierungsunterstützung ist entscheidend für große Web-Anwendungen.",
@@ -21,12 +22,10 @@
   "boilerplate.containers.FeaturePage.scaffolding.message": "Automatisieren Sie die Kreation von Komponenten, Containern, Routen, Selektoren und Sagas – und ihre Tests – direkt von dem Terminal!",
   "boilerplate.containers.FeaturePage.state_management.header": "Berechenbare Stateverwaltung",
   "boilerplate.containers.FeaturePage.state_management.message": "Unidirectional data flow erlaubt uns alle Änderungen ihrer Applikation zu loggen und time travel debugging einzusetzen.",
-  "boilerplate.containers.HomePage.features.Button": "",
   "boilerplate.containers.HomePage.start_project.header": "Beginnen Sie Ihr nächstes React Projekt in Sekunden",
   "boilerplate.containers.HomePage.start_project.message": "Ein skalierendes, offline-first Fundament mit der besten DX und einem Fokus auf Performance und bewährte Methoden",
   "boilerplate.containers.HomePage.tryme.atPrefix": "",
   "boilerplate.containers.HomePage.tryme.header": "Probiere mich!",
   "boilerplate.containers.HomePage.tryme.message": "Zeige die Github Repositories von",
-  "boilerplate.containers.NotFoundPage.header": "Seite nicht gefunden.",
-  "boilerplate.containers.NotFoundPage.home": ""
+  "boilerplate.containers.NotFoundPage.header": "Seite nicht gefunden."
 }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1,12 +1,13 @@
 {
   "boilerplate.components.Footer.author.message": "Made with love by {author}.",
   "boilerplate.components.Footer.license.message": "This project is licensed under the MIT license.",
+  "boilerplate.components.Header.home": "Home",
+  "boilerplate.containers.Header.features": "Features",
   "boilerplate.containers.FeaturePage.css.header": "Features",
   "boilerplate.containers.FeaturePage.css.message": "Next generation CSS",
   "boilerplate.containers.FeaturePage.feedback.header": "Instant feedback",
   "boilerplate.containers.FeaturePage.feedback.message": "Enjoy the best DX and code your app at the speed of thought! Your\n    saved changes to the CSS and JS are reflected instantaneously\n    without refreshing the page. Preserve application state even when\n    you update something in the underlying code!",
   "boilerplate.containers.FeaturePage.header": "Features",
-  "boilerplate.containers.FeaturePage.home": "Home",
   "boilerplate.containers.FeaturePage.internationalization.header": "Complete i18n Standard Internationalization & Pluralization",
   "boilerplate.containers.FeaturePage.internationalization.message": "Scalable apps need to support multiple languages, easily add and support multiple languages with `react-intl`.",
   "boilerplate.containers.FeaturePage.javascript.header": "Next generation JavaScript",
@@ -19,12 +20,10 @@
   "boilerplate.containers.FeaturePage.scaffolding.message": "Automate the creation of components, containers, routes, selectors\n  and sagas - and their tests - right from the CLI!",
   "boilerplate.containers.FeaturePage.state_management.header": "Predictable state management",
   "boilerplate.containers.FeaturePage.state_management.message": "Unidirectional data flow allows for change logging and time travel\n    debugging.",
-  "boilerplate.containers.HomePage.features.Button": "Features",
   "boilerplate.containers.HomePage.start_project.header": "Start your next react project in seconds",
   "boilerplate.containers.HomePage.start_project.message": "A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices",
   "boilerplate.containers.HomePage.tryme.atPrefix": "@",
   "boilerplate.containers.HomePage.tryme.header": "Try me!",
   "boilerplate.containers.HomePage.tryme.message": "Show Github repositories by",
-  "boilerplate.containers.NotFoundPage.header": "Page not found.",
-  "boilerplate.containers.NotFoundPage.home": "Home"
+  "boilerplate.containers.NotFoundPage.header": "Page not found."
 }


### PR DESCRIPTION
- simplifies code with `Link` instead of `dispatch(push(...))`
- moves navigation buttons to header to be accessible from all pages and reduce code repetition
- highlights nav buttons when their target matches current browser location, to make more clear what current page is
- makes it easier for projects to then quickly customise navigation

Tested redux + react-router integration still works as expected using Redux DevTools, can replay navigation changes.

<img width="872" alt="screen shot 2016-10-06 at 12 47 05" src="https://cloud.githubusercontent.com/assets/4217871/19147913/0e7a4596-8bc3-11e6-9c24-a915c0293c87.png">
