### PR TITLE
remove unnecessary `fromJS` call

### DIFF
--- a/app/containers/App/reducer.js
+++ b/app/containers/App/reducer.js
@@ -22,9 +22,9 @@ const initialState = fromJS({
   loading: false,
   error: false,
   currentUser: false,
-  userData: fromJS({
+  userData: {
     repositories: false,
-  }),
+  },
 });
 
 function appReducer(state = initialState, action) {


### PR DESCRIPTION
`fromJS` will convert deep structures (object to Map, array to List). Since we already have one `fromJS` call - we need no second call