### PR TITLE
automatically cancel running sagas on location change

### DIFF
--- a/app/containers/HomePage/sagas.js
+++ b/app/containers/HomePage/sagas.js
@@ -2,8 +2,7 @@
  * Gets the repositories of the user from Github
  */
 
-import { take, call, put, select, fork, cancel } from 'redux-saga/effects';
-import { LOCATION_CHANGE } from 'react-router-redux';
+import { take, call, put, select } from 'redux-saga/effects';
 import { LOAD_REPOS } from 'containers/App/constants';
 import { reposLoaded, repoLoadingError } from 'containers/App/actions';
 
@@ -37,19 +36,7 @@ export function* getReposWatcher() {
   }
 }
 
-/**
- * Root saga manages watcher lifecycle
- */
-export function* githubData() {
-  // Fork watcher so we can continue execution
-  const watcher = yield fork(getReposWatcher);
-
-  // Suspend execution until location changes
-  yield take(LOCATION_CHANGE);
-  yield cancel(watcher);
-}
-
 // Bootstrap sagas
 export default [
-  githubData,
+  getReposWatcher,
 ];

--- a/app/containers/HomePage/tests/sagas.test.js
+++ b/app/containers/HomePage/tests/sagas.test.js
@@ -3,10 +3,9 @@
  */
 
 import expect from 'expect';
-import { take, call, put, select, fork, cancel } from 'redux-saga/effects';
-import { LOCATION_CHANGE } from 'react-router-redux';
+import { take, call, put, select } from 'redux-saga/effects';
 
-import { getRepos, getReposWatcher, githubData } from '../sagas';
+import { getRepos, getReposWatcher } from '../sagas';
 
 import { LOAD_REPOS } from 'containers/App/constants';
 import { reposLoaded, repoLoadingError } from 'containers/App/actions';
@@ -65,28 +64,4 @@ describe('getReposWatcher Saga', () => {
     const callDescriptor = getReposWatcherGenerator.next(put(LOAD_REPOS)).value;
     expect(callDescriptor).toEqual(call(getRepos));
   });
-});
-
-describe('githubDataSaga Saga', () => {
-  const githubDataSaga = githubData();
-
-  let forkDescriptor;
-
-  it('should asyncronously fork getReposWatcher saga', () => {
-    forkDescriptor = githubDataSaga.next();
-    expect(forkDescriptor.value).toEqual(fork(getReposWatcher));
-  });
-
-  it('should yield until LOCATION_CHANGE action', () => {
-    const takeDescriptor = githubDataSaga.next();
-    expect(takeDescriptor.value).toEqual(take(LOCATION_CHANGE));
-  });
-
-  it('should finally cancel() the forked getReposWatcher saga',
-    function* githubDataSagaCancellable() {
-      // reuse open fork for more integrated approach
-      forkDescriptor = githubDataSaga.next(put(LOCATION_CHANGE));
-      expect(forkDescriptor.value).toEqual(cancel(forkDescriptor));
-    }
-  );
 });

--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -1,4 +1,6 @@
 import { conformsTo, isEmpty, isFunction, isObject, isString } from 'lodash';
+import { LOCATION_CHANGE } from 'react-router-redux';
+import { fork, cancel, take } from 'redux-saga/effects';
 import invariant from 'invariant';
 import warning from 'warning';
 import createReducer from '../reducers';
@@ -57,8 +59,18 @@ export function injectAsyncSagas(store, isValid) {
       '(app/utils...) injectAsyncSagas: Received an empty `sagas` array'
     );
 
-    sagas.map(store.runSaga);
+    store.runSaga(combineSagas.bind(null, sagas));
   };
+}
+
+/**
+ * Combine asynchronously loaded sagas for injection
+ */
+export function* combineSagas(sagas) {
+  const forkedSagas = yield sagas.map(fork);
+  yield take(LOCATION_CHANGE);
+  yield forkedSagas.map(cancel);
+  return;
 }
 
 /**


### PR DESCRIPTION
Currently sagas associated with a route are loaded asynchronously as many times, as the user of an application has entered that route. To circumvent this, developers have to wrap each of their sagas in a `fork - take(LOCATION_CHANGE) - cancel` block. 

Sagas are not meant to be duplicated by default - if a developer wants their saga to run as many times, as the user has visited a route, then redux-saga provides a way to do that using the "spawn" effect, and it would be best to explicitly state that this is happening in the application's code, not implicitly have it happen by NOT doing something in the code.

At least as long as there is no solution preventing the router from ever loading a saga that is already running, I think at least this much can be done to make sagas run as if they were not loaded asynchronously.