### PR TITLE
Update Redux DevTools Extension's usage according to new API

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -50,15 +50,6 @@ import { translationMessages } from './i18n';
 const initialState = {};
 const store = configureStore(initialState, browserHistory);
 
-// If you use Redux devTools extension, since v2.0.1, they added an
-// `updateStore`, so any enhancers that change the store object
-// could be used with the devTools' store.
-// As this boilerplate uses Redux & Redux-Saga, the `updateStore` is needed
-// if you want to `take` actions in your Sagas, dispatched from devTools.
-if (window.devToolsExtension) {
-  window.devToolsExtension.updateStore(store);
-}
-
 // Sync history and store, as the react-router-redux reducer
 // is under the non-default key ("routing"), selectLocationState
 // must be provided for resolving how to retrieve the "route" in the state

--- a/app/store.js
+++ b/app/store.js
@@ -9,7 +9,6 @@ import createSagaMiddleware from 'redux-saga';
 import createReducer from './reducers';
 
 const sagaMiddleware = createSagaMiddleware();
-const devtools = window.devToolsExtension || (() => (noop) => noop);
 
 export default function configureStore(initialState = {}, history) {
   // Create the store with two middlewares
@@ -22,13 +21,17 @@ export default function configureStore(initialState = {}, history) {
 
   const enhancers = [
     applyMiddleware(...middlewares),
-    devtools(),
   ];
+
+  // If Redux DevTools Extension is installed use it, otherwise use Redux compose
+  /* eslint-disable no-underscore-dangle */
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  /* eslint-enable */
 
   const store = createStore(
     createReducer(),
     fromJS(initialState),
-    compose(...enhancers)
+    composeEnhancers(...enhancers)
   );
 
   // Extensions


### PR DESCRIPTION
[`window.devToolsExtension` is being deprecated](https://github.com/zalmoxisus/redux-devtools-extension/issues/220) in favour of a more clear API. There's no need for `window.devToolsExtension.updateStore` workaround anymore, which invokes misconceptions like https://github.com/zalmoxisus/redux-devtools-extension/issues/231.

[Here](https://medium.com/@zalmoxis/improve-your-development-workflow-with-redux-devtools-extension-f0379227ff83)'s a blog post with more details. Also [there's an npm package](https://github.com/zalmoxisus/redux-devtools-extension#13-use-redux-devtools-extension-package-from-npm) to make things even easier.