### PR TITLE
Add shouldComponentUpdate to FeaturePage (demo)

### DIFF
--- a/app/containers/FeaturePage/index.js
+++ b/app/containers/FeaturePage/index.js
@@ -14,6 +14,13 @@ import ListItem from './ListItem';
 import ListItemTitle from './ListItemTitle';
 
 export default class FeaturePage extends React.Component { // eslint-disable-line react/prefer-stateless-function
+
+  // Since state and props are static,
+  // there's no need to re-render this component
+  shouldComponentUpdate() {
+    return false;
+  }
+
   render() {
     return (
       <div>


### PR DESCRIPTION
companion to #811

the `FeaturePage` component class slipped through the cracks of #811, since it used to be a functional component when the pull was first opened... but when i thought about it, this page doesn't really fit the bill for `PureComponent` either. it doesn't need any external props or state to render itself. this is idiomatic use case for `shouldComponentUpdate`—the component only needs to render 1x. the demo is a cool way to expose these simple patterns which might not be obvious to someone new to react... for example, they might ask themselves why using this optimization on a parent component doesn't break it's descendants. in this case, why do the `react-intl` child components still update (ie when toggling locale)? 📚 