### PR TITLE
Fix 'npm run clean' breaking (#1185)

### DIFF
--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-const addCheckMark = require('./helpers/checkmark.js'); 
+const addCheckMark = require('./helpers/checkmark.js');
 
 if (!which('git')) {
   echo('Sorry, this script requires git');
@@ -22,6 +22,7 @@ mkdir('-p', 'app/containers/App');
 mkdir('-p', 'app/containers/NotFoundPage');
 mkdir('-p', 'app/containers/HomePage');
 cp('internals/templates/appContainer.js', 'app/containers/App/index.js');
+cp('internals/templates/constants.js', 'app/containers/App/constants.js');
 cp('internals/templates/notFoundPage/notFoundPage.js', 'app/containers/NotFoundPage/index.js');
 cp('internals/templates/notFoundPage/messages.js', 'app/containers/NotFoundPage/messages.js');
 cp('internals/templates/homePage/homePage.js', 'app/containers/HomePage/index.js');

--- a/internals/templates/constants.js
+++ b/internals/templates/constants.js
@@ -1,0 +1,12 @@
+/*
+ * AppConstants
+ * Each action has a corresponding type, which the reducer knows and picks up on.
+ * To avoid weird typos between the reducer and the actions, we save them as
+ * constants here. We prefix them with 'yourproject/YourComponent' so we avoid
+ * reducers accidentally picking up actions they shouldn't.
+ *
+ * Follow this format:
+ * export const YOUR_ACTION_CONSTANT = 'yourproject/YourContainer/YOUR_ACTION_CONSTANT';
+ */
+
+export const DEFAULT_LOCALE = 'en';


### PR DESCRIPTION
-Added a constants.js file to templates with the DEFAULT_LOCALE export
-Added a line in clean.js to copy the templates/constants.js file to containers/App/

This resolves the issue of npm run clean breaking because of constants.js not being found since it was being deleted on npm run clean.