### PR TITLE
Fix i18n button not updating (#1181)

### DIFF
--- a/app/components/Toggle/index.js
+++ b/app/components/Toggle/index.js
@@ -20,7 +20,7 @@ function Toggle(props) {
   }
 
   return (
-    <Select onChange={props.onToggle}>
+    <Select value={props.value} onChange={props.onToggle}>
       {content}
     </Select>
   );
@@ -29,6 +29,7 @@ function Toggle(props) {
 Toggle.propTypes = {
   onToggle: React.PropTypes.func,
   values: React.PropTypes.array,
+  value: React.PropTypes.string,
   messages: React.PropTypes.object,
 };
 

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -19,7 +19,7 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
   render() {
     return (
       <Wrapper>
-        <Toggle values={appLocales} messages={messages} onToggle={this.props.onLocaleToggle} />
+        <Toggle value={this.props.locale} values={appLocales} messages={messages} onToggle={this.props.onLocaleToggle} />
       </Wrapper>
     );
   }
@@ -27,6 +27,7 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
 
 LocaleToggle.propTypes = {
   onLocaleToggle: React.PropTypes.func,
+  locale: React.PropTypes.string,
 };
 
 const mapStateToProps = createSelector(


### PR DESCRIPTION
Added a value prop to the Toggle component, being passed down to the Select component to explicitly state which option is selected. The problem seemed to be that when selecting a new language, the component would re-render the options in the order they are passed down via the values prop, thus causing the error.