### PR TITLE
Fix incorrect import path in i18n.js

### DIFF
--- a/internals/templates/i18n.js
+++ b/internals/templates/i18n.js
@@ -5,7 +5,7 @@
  *
  */
 import { addLocaleData } from 'react-intl';
-import { DEFAULT_LOCALE } from 'containers/App/constants';
+import { DEFAULT_LOCALE } from './containers/App/constants';
 
 import enLocaleData from 'react-intl/locale-data/en';
 


### PR DESCRIPTION
This issue occurred when running:

```
git clone --depth=1 https://github.com/mxstbr/react-boilerplate.git
npm run setup
npm run clean
npm run generate language
```

We got:

```
> react-boilerplate@3.3.1 generate /Users/yan/Projects/react-boilerplate
> plop --plopfile internals/generators/index.js "language"

? [LANGUAGE] What is the language you want to add i18n support for (e.g. "fr", "de")? da
/Users/yan/Projects/react-boilerplate/internals/generators/language/index.js:71
            throw err || stderr;
            ^

Error: Command failed: npm run extract-intl
module.js:471
    throw err;
    ^

Error: Cannot find module 'containers/App/constants'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/yan/Projects/react-boilerplate/app/i18n.js:8:1)
    at Module._compile (module.js:570:32)
    at loader (/Users/yan/Projects/react-boilerplate/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/yan/Projects/react-boilerplate/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```