### PR TITLE
Node version support update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
+  - 7
   - 6
   - 5
-  - 4
 
 script: npm run build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
 
   matrix:
     # Node versions to run
+    - nodejs_version: 7
     - nodejs_version: 6
     - nodejs_version: 5
-    - nodejs_version: 4
 
 # Fix line endings in Windows. (runs before repo cloning)
 init:

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -204,7 +204,7 @@ pipelines:
 ## I'm using Node v0.12 and the server doesn't work?
 
 We settled on supporting the last three major Node.js versions for the boilerplate – at the moment
-of this writing those are v4, v5 and v6. We **highly recommend upgrading to a newer Node.js version**!
+of this writing those are v5, v6 and v7. We **highly recommend upgrading to a newer Node.js version**!
 
 If you _have_ to use Node.js 0.12, you can hack around the server not running by using `babel-cli` to
 run the server: `npm install babel-cli`, and then replace all instances of `node server` in the `"scripts"`

--- a/internals/generators/component/index.js
+++ b/internals/generators/component/index.js
@@ -2,6 +2,10 @@
  * Component Generator
  */
 
+/* eslint strict: ["off"] */
+
+'use strict';
+
 const componentExists = require('../utils/componentExists');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mxstbr/react-boilerplate.git"
   },
   "engines": {
-    "npm": ">=3"
+    "npm": ">=5"
   },
   "author": "Max Stoiber",
   "license": "MIT",


### PR DESCRIPTION
If using Node v5 or older and you followed the steps listed in **issue #1189**, it would fail on both macOS and Windows.

According to [Node Green](http://node.green/#let), Node v5 should support the use of `let`, but it appears that this is not true given the error. To resolve this I've added `use strict` to the top of `internals/generators/component/index.js`.

As this boilerplate supports the last three major versions of Node.js, see [FAQs](https://github.com/mxstbr/react-boilerplate/blob/master/docs/general/faq.md#im-using-node-v012-and-the-server-doesnt-work), this change also includes doc updates along with an improved `setup.js` that will exit on old versions of Node.