### PR TITLE
Fix console error on lang change

### DIFF
--- a/app/components/Toggle/tests/index.test.js
+++ b/app/components/Toggle/tests/index.test.js
@@ -10,11 +10,11 @@ describe('<Toggle />', () => {
     const defaultDeMessage = 'someOtherContent';
     const messages = defineMessages({
       en: {
-        id: 'app.components.LocaleToggle.en',
+        id: 'boilerplate.containers.LocaleToggle.en',
         defaultMessage: defaultEnMessage,
       },
       de: {
-        id: 'app.components.LocaleToggle.en',
+        id: 'boilerplate.containers.LocaleToggle.en',
         defaultMessage: defaultDeMessage,
       },
     });

--- a/app/components/ToggleOption/tests/index.test.js
+++ b/app/components/ToggleOption/tests/index.test.js
@@ -9,7 +9,7 @@ describe('<ToggleOption />', () => {
     const defaultEnMessage = 'someContent';
     const message = defineMessages({
       enMessage: {
-        id: 'app.components.LocaleToggle.en',
+        id: 'boilerplate.containers.LocaleToggle.en',
         defaultMessage: defaultEnMessage,
       },
     });

--- a/app/containers/LocaleToggle/messages.js
+++ b/app/containers/LocaleToggle/messages.js
@@ -10,7 +10,7 @@ export function getLocaleMessages(locales) {
   return locales.reduce((messages, locale) =>
     Object.assign(messages, {
       [locale]: {
-        id: `app.components.LocaleToggle.${locale}`,
+        id: `boilerplate.containers.LocaleToggle.${locale}`,
         defaultMessage: `${locale}`,
       },
     }), {});

--- a/app/containers/LocaleToggle/tests/messages.test.js
+++ b/app/containers/LocaleToggle/tests/messages.test.js
@@ -4,11 +4,11 @@ describe('getLocaleMessages', () => {
   it('should create i18n messages for all locales', () => {
     const expected = {
       en: {
-        id: 'app.components.LocaleToggle.en',
+        id: 'boilerplate.containers.LocaleToggle.en',
         defaultMessage: 'en',
       },
       fr: {
-        id: 'app.components.LocaleToggle.fr',
+        id: 'boilerplate.containers.LocaleToggle.fr',
         defaultMessage: 'fr',
       },
     };

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -1,10 +1,8 @@
 {
-  "app.components.LocaleToggle.de": "",
-  "app.components.LocaleToggle.en": "",
   "boilerplate.components.Footer.author.message": "Mit Liebe gemacht von {author}.",
   "boilerplate.components.Footer.license.message": "Dieses Projekt wird unter der MIT-Lizenz veröffentlicht.",
+  "boilerplate.components.Header.features": "",
   "boilerplate.components.Header.home": "",
-  "boilerplate.containers.Header.features": "",
   "boilerplate.containers.FeaturePage.css.header": "",
   "boilerplate.containers.FeaturePage.css.message": "Die nächste Generation von CSS",
   "boilerplate.containers.FeaturePage.feedback.header": "Sofortiges Feedback",
@@ -27,5 +25,7 @@
   "boilerplate.containers.HomePage.tryme.atPrefix": "",
   "boilerplate.containers.HomePage.tryme.header": "Probiere mich!",
   "boilerplate.containers.HomePage.tryme.message": "Zeige die Github Repositories von",
+  "boilerplate.containers.LocaleToggle.de": "",
+  "boilerplate.containers.LocaleToggle.en": "",
   "boilerplate.containers.NotFoundPage.header": "Seite nicht gefunden."
 }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1,8 +1,8 @@
 {
   "boilerplate.components.Footer.author.message": "Made with love by {author}.",
   "boilerplate.components.Footer.license.message": "This project is licensed under the MIT license.",
+  "boilerplate.components.Header.features": "Features",
   "boilerplate.components.Header.home": "Home",
-  "boilerplate.containers.Header.features": "Features",
   "boilerplate.containers.FeaturePage.css.header": "Features",
   "boilerplate.containers.FeaturePage.css.message": "Next generation CSS",
   "boilerplate.containers.FeaturePage.feedback.header": "Instant feedback",
@@ -25,5 +25,7 @@
   "boilerplate.containers.HomePage.tryme.atPrefix": "@",
   "boilerplate.containers.HomePage.tryme.header": "Try me!",
   "boilerplate.containers.HomePage.tryme.message": "Show Github repositories by",
+  "boilerplate.containers.LocaleToggle.de": "de",
+  "boilerplate.containers.LocaleToggle.en": "en",
   "boilerplate.containers.NotFoundPage.header": "Page not found."
 }


### PR DESCRIPTION
This is a fix for Issues #1196, which throws "[React Intl] Missing message" errors to the console when changing language with the locale toggle in the application footer.

*Note: while this fixes this specific problem, there are outstanding still issues when generating new languages with the command `npm run generate language`  (see #1191) .*