### PR TITLE
Replace start:prod with independent start:production

### DIFF
--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -60,10 +60,10 @@ accessible anywhere! Changes in the application code will be hot-reloaded.
 ### Production
 
 ```Shell
-npm run start:prod
+npm run start:production
 ```
 
-Starts the production server, configured for optimal performance: assets are
+Starts the production server, building the app for optimal performance: assets are
 minified and served gzipped.
 
 ### Port


### PR DESCRIPTION
The docs are a little confusing on how to get a prod server started. `start:prod` has a undeclared dependency on `build`. So instead, switching the docs to reference the more independent `start:production` cmd is easier for people to follow.