### PR TITLE
Fix default Intl polyfill language

### DIFF
--- a/internals/templates/app.js
+++ b/internals/templates/app.js
@@ -87,7 +87,7 @@ if (!window.Intl) {
     resolve(System.import('intl'));
   }))
     .then(() => Promise.all([
-      System.import('intl/locale-data/jsonp/de.js'),
+      System.import('intl/locale-data/jsonp/en.js'),
     ]))
     .then(() => render(translationMessages))
     .catch((err) => {


### PR DESCRIPTION
When we remove example app, default language is English, not German.