### PR TITLE
fix(example): Use `createStructuredSelector` instead of `createSelector` in `RepoListItem`

### DIFF
--- a/app/containers/RepoListItem/index.js
+++ b/app/containers/RepoListItem/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 import { FormattedNumber } from 'react-intl';
 
 import IssueIcon from './IssueIcon';
@@ -52,6 +52,6 @@ RepoListItem.propTypes = {
   currentUser: React.PropTypes.string,
 };
 
-export default connect(createSelector({
+export default connect(createStructuredSelector({
   currentUser: selectCurrentUser(),
 }))(RepoListItem);


### PR DESCRIPTION
Currently the example app in the dev branch shows an error message when you try to fetch information:

![image](https://cloud.githubusercontent.com/assets/387256/20073614/8fec5c6e-a535-11e6-9e21-251d15a85c62.png)

`git bisect` pointed me to the Jest integration commit and there I noticed this change: https://github.com/mxstbr/react-boilerplate/commit/98f2d0d931ad0945961b66047b47f519734c9db2#diff-f66d28b72b146f6d22bdc2e7aab68001L57 that broke `RepoListItem` component; unless I'm missing something, it's better to replace `createSelector` with `createStructuredSelector` to fix this error.