### PR TITLE
Disable ESLint rule: no-confusing-arrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       "jsx-a11y/role-supports-aria-props": 2,
       "max-len": 0,
       "newline-per-chained-call": 0,
+      "no-confusing-arrow": 0,
       "no-console": 1,
       "no-use-before-define": 0,
       "prefer-template": 2,


### PR DESCRIPTION
Globally disable the ESLint rule (no-confusing-arrow) as per discussion in #1237 
