### PR TITLE
chore(test config): expand Jest config to include common file types

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,8 +192,8 @@
       "app"
     ],
     "moduleNameMapper": {
-      ".*\\.css$": "<rootDir>/mocks/cssModule.js",
-      ".*\\.jpg$": "<rootDir>/mocks/image.js"
+      ".*\\.(css|less|styl|scss|sass)$": "<rootDir>/mocks/cssModule.js",
+      ".*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/image.js"
     },
     "setupTestFrameworkScriptFile": "<rootDir>/internals/testing/test-bundler.js",
     "testRegex": "tests/.*\\.test\\.js$"


### PR DESCRIPTION
chore(test config): expand Jest moduleNameMapper key to include common file types.

Resolves #1292