### PR TITLE
Add ability to create daemon sagas

### DIFF
--- a/app/store.js
+++ b/app/store.js
@@ -41,6 +41,7 @@ export default function configureStore(initialState = {}, history) {
   // Extensions
   store.runSaga = sagaMiddleware.run;
   store.asyncReducers = {}; // Async reducer registry
+  store.asyncSagas = {}; // Async saga registry
 
   // Make reducers hot reloadable, see http://mxs.is/googmo
   /* istanbul ignore next */

--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -57,7 +57,12 @@ export function injectAsyncSagas(store, isValid) {
       '(app/utils...) injectAsyncSagas: Received an empty `sagas` array'
     );
 
-    sagas.map(store.runSaga);
+    sagas.forEach((saga) => {
+      if (!(saga.isDaemon === true && Reflect.has(store.asyncSagas, saga))) {
+        store.asyncSagas[saga] = true; // eslint-disable-line no-param-reassign
+        store.runSaga(saga);
+      }
+    });
   };
 }
 


### PR DESCRIPTION
This PR fixes #1183 with 100% backward compatibility. Now we are able to create daemon sagas. Daemon sagas run only once (when loaded), next time injector ignore them. So, we don't need to track `LOCATION_CHANGE` and manually stop simple sagas to prevent duplicates: we just need to set `isDaemon` attribute of saga to `true` and that's it!

Before:
```javascript
/**
 * Watches for LOAD_REPOS actions and calls getRepos when one comes in.
 * By using `takeLatest` only the result of the latest API call is applied.
 */
export function* getReposWatcher() {
  yield fork(takeLatest, LOAD_REPOS, getRepos);
}

/**
 * Root saga manages watcher lifecycle
 */
export function* githubData() {
  // Fork watcher so we can continue execution
  const watcher = yield fork(getReposWatcher);

  // Suspend execution until location changes
  yield take(LOCATION_CHANGE);
  yield cancel(watcher);
}

// Bootstrap sagas
export default [
  githubData,
];
```

After:
```javascript
/**
 * Watches for LOAD_REPOS actions and calls getRepos when one comes in.
 * By using `takeLatest` only the result of the latest API call is applied.
 */
export function* getReposWatcher() {
  yield fork(takeLatest, LOAD_REPOS, getRepos);
}
getReposWatcher.isDaemon = true;

// Bootstrap sagas
export default [
  getReposWatcher,
];
```