### PR TITLE
fix(templates): use correct name of a selector

### DIFF
--- a/internals/templates/languageProvider/languageProvider.js
+++ b/internals/templates/languageProvider/languageProvider.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { IntlProvider } from 'react-intl';
 
-import { selectLocale } from './selectors';
+import { makeSelectLocale } from './selectors';
 
 export class LanguageProvider extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
   render() {
@@ -31,7 +31,7 @@ LanguageProvider.propTypes = {
 
 
 const mapStateToProps = createSelector(
-  selectLocale(),
+  makeSelectLocale(),
   (locale) => ({ locale })
 );
 


### PR DESCRIPTION
Fixes regression introduced in #1205, #1320 can be closed once we merge this one.