### PR TITLE
fix(generator):  'generate container' produces unnecessary return

### DIFF
--- a/internals/generators/container/sagas.js.hbs
+++ b/internals/generators/container/sagas.js.hbs
@@ -2,7 +2,7 @@
 
 // Individual exports for testing
 export function* defaultSaga() {
-  return;
+  return null;
 }
 
 // All sagas to be loaded


### PR DESCRIPTION
There may well be a better solution, but this eliminates the immediate problem.

Resolves #1231

Open to suggestions.