### PR TITLE
chore(internals): fix indentation in 'routeWithReducer'

### DIFF
--- a/internals/generators/route/routeWithReducer.hbs
+++ b/internals/generators/route/routeWithReducer.hbs
@@ -1,25 +1,25 @@
-{
-  path: '{{ path }}',
-  name: '{{ camelCase component }}',
-  getComponent(nextState, cb) {
-    const importModules = Promise.all([
-      System.import('containers/{{ properCase component }}/reducer'),
-      {{#if useSagas}}
-      System.import('containers/{{ properCase component }}/sagas'),
-      {{/if}}
-      System.import('containers/{{ properCase component }}'),
-    ]);
+ {
+      path: '{{ path }}',
+      name: '{{ camelCase component }}',
+      getComponent(nextState, cb) {
+        const importModules = Promise.all([
+          System.import('containers/{{ properCase component }}/reducer'),
+          {{#if useSagas}}
+          System.import('containers/{{ properCase component }}/sagas'),
+          {{/if}}
+          System.import('containers/{{ properCase component }}'),
+        ]);
 
-    const renderRoute = loadModule(cb);
+        const renderRoute = loadModule(cb);
 
-    importModules.then(([reducer,{{#if useSagas}} sagas,{{/if}} component]) => {
-      injectReducer('{{ camelCase component }}', reducer.default);
-      {{#if useSagas}}
-      injectSagas(sagas.default);
-      {{/if}}
-      renderRoute(component);
-    });
+        importModules.then(([reducer,{{#if useSagas}} sagas,{{/if}} component]) => {
+          injectReducer('{{ camelCase component }}', reducer.default);
+          {{#if useSagas}}
+          injectSagas(sagas.default);
+          {{/if}}
+          renderRoute(component);
+        });
 
-    importModules.catch(errorLoading);
-  },
-},$1
+        importModules.catch(errorLoading);
+      },
+    },$1


### PR DESCRIPTION
`npm run generate route`, for a container with a reducer, for example a `HomePage` component, expected result:

```js
    }, {
      path: '/test',
      name: 'homePage',
      getComponent(nextState, cb) {
        const importModules = Promise.all([
          System.import('containers/HomePage/reducer'),
          System.import('containers/HomePage/sagas'),
          System.import('containers/HomePage'),
        ]);

        const renderRoute = loadModule(cb);

        importModules.then(([reducer, sagas, component]) => {
          injectReducer('homePage', reducer.default);
          injectSagas(sagas.default);
          renderRoute(component);
        });

        importModules.catch(errorLoading);
      },
    }, {
```

current result:

```js
    },{
  path: '/test',
  name: 'homePage',
  getComponent(nextState, cb) {
    const importModules = Promise.all([
      System.import('containers/HomePage/reducer'),
      System.import('containers/HomePage/sagas'),
      System.import('containers/HomePage'),
    ]);

    const renderRoute = loadModule(cb);

    importModules.then(([reducer, sagas, component]) => {
      injectReducer('homePage', reducer.default);
      injectSagas(sagas.default);
      renderRoute(component);
    });

    importModules.catch(errorLoading);
  },
}, {
```