### PR TITLE
fix(generators, templates): add example app functionality into project templates and generators

### DIFF
--- a/app/containers/HomePage/tests/sagas.test.js
+++ b/app/containers/HomePage/tests/sagas.test.js
@@ -13,6 +13,7 @@ import { getRepos, getReposWatcher, githubData } from '../sagas';
 
 const username = 'mxstbr';
 
+/* eslint-disable redux-saga/yield-effects */
 describe('getRepos Saga', () => {
   let getReposGenerator;
 

--- a/internals/generators/component/es6.js.hbs
+++ b/internals/generators/component/es6.js.hbs
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+// import styled from 'styled-components';
 
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -22,5 +23,9 @@ class {{ properCase name }} extends React.Component { // eslint-disable-line rea
     );
   }
 }
+
+{{ properCase name }}.propTypes = {
+
+};
 
 export default {{ properCase name }};

--- a/internals/generators/component/es6.pure.js.hbs
+++ b/internals/generators/component/es6.pure.js.hbs
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+// import styled from 'styled-components';
 
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -22,5 +23,9 @@ class {{ properCase name }} extends React.PureComponent { // eslint-disable-line
     );
   }
 }
+
+{{ properCase name }}.propTypes = {
+
+};
 
 export default {{ properCase name }};

--- a/internals/generators/component/stateless.js.hbs
+++ b/internals/generators/component/stateless.js.hbs
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+// import styled from 'styled-components';
 
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
@@ -20,5 +21,9 @@ function {{ properCase name }}() {
     </div>
   );
 }
+
+{{ properCase name }}.propTypes = {
+
+};
 
 export default {{ properCase name }};

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -4,7 +4,7 @@
  *
  */
 
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 {{#if wantHeaders}}
 import Helmet from 'react-helmet';
@@ -14,6 +14,7 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 {{/if}}
 {{#if wantActionsAndReducer}}
+import { createStructuredSelector } from 'reselect'; // eslint-disable-line import/first
 import makeSelect{{properCase name}} from './selectors';
 {{/if}}
 
@@ -37,8 +38,14 @@ export class {{ properCase name }} extends React.{{{ component }}} { // eslint-d
   }
 }
 
+{{ properCase name }}.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
 {{#if wantActionsAndReducer}}
-const mapStateToProps = makeSelect{{properCase name}}();
+const mapStateToProps = createStructuredSelector({
+  {{name}}: makeSelect{{properCase name}}(),
+});
 {{/if}}
 
 function mapDispatchToProps(dispatch) {

--- a/internals/generators/container/index.js.hbs
+++ b/internals/generators/container/index.js.hbs
@@ -11,11 +11,13 @@ import Helmet from 'react-helmet';
 {{/if}}
 {{#if wantMessages}}
 import { FormattedMessage } from 'react-intl';
-import messages from './messages';
 {{/if}}
 {{#if wantActionsAndReducer}}
-import { createStructuredSelector } from 'reselect'; // eslint-disable-line import/first
+import { createStructuredSelector } from 'reselect';
 import makeSelect{{properCase name}} from './selectors';
+{{/if}}
+{{#if wantMessages}}
+import messages from './messages';
 {{/if}}
 
 export class {{ properCase name }} extends React.{{{ component }}} { // eslint-disable-line react/prefer-stateless-function

--- a/internals/generators/container/sagas.test.js.hbs
+++ b/internals/generators/container/sagas.test.js.hbs
@@ -2,7 +2,7 @@
  * Test  sagas
  */
 
-
+/* eslint-disable redux-saga/yield-effects */
 // import { take, call, put, select } from 'redux-saga/effects';
 // import { defaultSaga } from '../sagas';
 

--- a/internals/templates/app.js
+++ b/internals/templates/app.js
@@ -38,6 +38,9 @@ import configureStore from './store';
 // Import i18n messages
 import { translationMessages } from './i18n';
 
+// Import CSS reset and Global Styles
+import './global-styles';
+
 // Import root routes
 import createRoutes from './routes';
 

--- a/internals/templates/global-styles.js
+++ b/internals/templates/global-styles.js
@@ -1,0 +1,30 @@
+import { injectGlobal } from 'styled-components';
+
+/* eslint no-unused-expressions: 0 */
+injectGlobal`
+  html,
+  body {
+    height: 100%;
+    width: 100%;
+  }
+
+  body {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  }
+
+  body.fontLoaded {
+    font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  }
+
+  #app {
+    background-color: #fafafa;
+    min-height: 100%;
+    min-width: 100%;
+  }
+
+  p,
+  label {
+    font-family: Georgia, Times, 'Times New Roman', serif;
+    line-height: 1.5em;
+  }
+`;


### PR DESCRIPTION
Implements recommendations from #1286 

The updates are slightly opinionated by including propTypes and styled-components. 
I considered replacing the <div> wrapping generated components with a ```styled.div``` Wrapper component, but was unsure if others would find it useful or annoying in the case they don't use them. 