### PR TITLE
fix(generator): 'generate container' produces unnecessary return - better solution

### DIFF
--- a/internals/generators/container/sagas.js.hbs
+++ b/internals/generators/container/sagas.js.hbs
@@ -2,7 +2,7 @@
 
 // Individual exports for testing
 export function* defaultSaga() {
-  return null;
+  // See example in containers/HomePage/sagas.js
 }
 
 // All sagas to be loaded

--- a/internals/generators/container/sagas.js.hbs
+++ b/internals/generators/container/sagas.js.hbs
@@ -2,7 +2,7 @@
 
 // Individual exports for testing
 export function* defaultSaga() {
-  return;
+  return null;
 }
 
 // All sagas to be loaded


### PR DESCRIPTION
Replaces the solution merged with #1327

A better solution. Handles the problem and guides the user (dev). See updated discussion in #1231