### PR TITLE
Rollback image-webpack-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "html-loader": "0.4.4",
     "html-webpack-plugin": "2.24.1",
     "circular-dependency-plugin": "2.0.0",
-    "image-webpack-loader": "3.0.0",
+    "image-webpack-loader": "2.0.0",
     "imports-loader": "0.6.5",
     "jest-cli": "17.0.3",
     "json-loader": "0.5.4",


### PR DESCRIPTION
Use v2 of `image-webpack-loader` as v3 requires environmental dependencies on mac, see #1335 

I'm not sure if we keep note of which dependencies are pinned anywhere? Should we create a doc for this?