### PR TITLE
Make `extract-intl` compatible with other babel plugins

### DIFF
--- a/internals/scripts/extract-intl.js
+++ b/internals/scripts/extract-intl.js
@@ -11,6 +11,9 @@ const animateProgress = require('./helpers/progress');
 const addCheckmark = require('./helpers/checkmark');
 
 const pkg = require('../../package.json');
+const presets = pkg.babel.presets;
+const plugins = pkg.babel.plugins || [];
+
 const i18n = require('../../app/i18n');
 import { DEFAULT_LOCALE } from '../../app/containers/App/constants';
 
@@ -76,16 +79,27 @@ for (const locale of locales) {
   }
 }
 
+/* push `react-intl` plugin to the existing plugins that are already configured in `package.json`
+   Example: 
+   ``` 
+  "babel": {
+    "plugins": [
+      ["transform-object-rest-spread", { "useBuiltIns": true }]
+    ],
+    "presets": [
+      "latest",
+      "react"
+    ]
+  }
+  ```
+*/
+plugins.push(['react-intl'])
+
 const extractFromFile = async (fileName) => {
   try {
     const code = await readFile(fileName);
     // Use babel plugin to extract instances where react-intl is used
-    const { metadata: result } = await transform(code, {
-      presets: pkg.babel.presets,
-      plugins: [
-        ['react-intl'],
-      ],
-    });
+    const { metadata: result } = await transform(code, { presets, plugins }); // object-shorthand
     for (const message of result['react-intl'].messages) {
       for (const locale of locales) {
         const oldLocaleMapping = oldLocaleMappings[locale][message.id];


### PR DESCRIPTION
Fix for https://github.com/mxstbr/react-boilerplate/issues/1354

-  Currently running `npm run extract-intl` works unless:
    User doesn't use other `babel-plugins`, specially transform-plugins such as 
   `transform-object-rest-spread`.
 
- The code repetitively reads `presets` information from `package.json`
 
- [x] double-check your branch is based on `dev` and targets `dev` 
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Description explains the issue/use-case resolved and auto-closes related issues



