### PR TITLE
Use node servers default host when none specified

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,10 @@ setup(app, {
 });
 
 // get the intended host and port number, use localhost and port 3000 if not provided
-const host = argv.host || process.env.HOST || 'localhost';
+const customHost = argv.host || process.env.HOST;
+const host = customHost || null; // Let http.Server use its default IPv6/4 host
+const prettyHost = customHost || 'localhost';
+
 const port = argv.port || process.env.PORT || 3000;
 
 // Start your app.
@@ -36,9 +39,9 @@ app.listen(port, host, (err) => {
         return logger.error(innerErr);
       }
 
-      logger.appStarted(port, host, url);
+      logger.appStarted(port, prettyHost, url);
     });
   } else {
-    logger.appStarted(port, host);
+    logger.appStarted(port, prettyHost);
   }
 });


### PR DESCRIPTION
Node's http.Server#listen does some smart choosing for default host '::' or '0.0.0.0' depending on IPv6 support. Use that instead of binding to localhost specifically. This mimics previous server functionality and allows ngrok access to work again.

This fixes #1398 