### PR TITLE
#1406 remove css lint documentation references

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,3 @@
+approvals = 2
+pattern  = "(?i):shipit:|LGTM"
+self_approval_off = true

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,9 @@
+mxstbr
+oliverturner
+justingreenberg
+gihrig
+sedubois
+chaintng
+samit4me
+amilajack
+Dattaya

--- a/app/components/Toggle/index.js
+++ b/app/components/Toggle/index.js
@@ -20,7 +20,7 @@ function Toggle(props) {
   }
 
   return (
-    <Select onChange={props.onToggle}>
+    <Select value={props.value} onChange={props.onToggle}>
       {content}
     </Select>
   );
@@ -29,6 +29,7 @@ function Toggle(props) {
 Toggle.propTypes = {
   onToggle: React.PropTypes.func,
   values: React.PropTypes.array,
+  value: React.PropTypes.string,
   messages: React.PropTypes.object,
 };
 

--- a/app/containers/LanguageProvider/reducer.js
+++ b/app/containers/LanguageProvider/reducer.js
@@ -8,9 +8,12 @@ import { fromJS } from 'immutable';
 import {
   CHANGE_LOCALE,
 } from './constants';
+import {
+  DEFAULT_LOCALE,
+} from '../App/constants';
 
 const initialState = fromJS({
-  locale: 'en',
+  locale: DEFAULT_LOCALE,
 });
 
 function languageProviderReducer(state = initialState, action) {

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -19,7 +19,7 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
   render() {
     return (
       <Wrapper>
-        <Toggle values={appLocales} messages={messages} onToggle={this.props.onLocaleToggle} />
+        <Toggle value={this.props.locale} values={appLocales} messages={messages} onToggle={this.props.onLocaleToggle} />
       </Wrapper>
     );
   }
@@ -27,6 +27,7 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
 
 LocaleToggle.propTypes = {
   onLocaleToggle: React.PropTypes.func,
+  locale: React.PropTypes.string,
 };
 
 const mapStateToProps = createSelector(

--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -171,7 +171,7 @@ about the bundle size.
 npm run lint
 ```
 
-Lints your JavaScript and CSS.
+Lints your JavaScript.
 
 ### JavaScript
 
@@ -180,11 +180,3 @@ npm run lint:js
 ```
 
 Only lints your JavaScript.
-
-### CSS
-
-```Shell
-npm run lint:css
-```
-
-Only lints your CSS.

--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -171,7 +171,7 @@ about the bundle size.
 npm run lint
 ```
 
-Lints your JavaScript.
+Lints your JavaScript<!-- and CSS-->.
 
 ### JavaScript
 
@@ -180,3 +180,11 @@ npm run lint:js
 ```
 
 Only lints your JavaScript.
+
+<!--### CSS
+
+```Shell
+npm run lint:css
+```
+
+Only lints your CSS.-->

--- a/docs/general/commands.md
+++ b/docs/general/commands.md
@@ -171,20 +171,5 @@ about the bundle size.
 npm run lint
 ```
 
-Lints your JavaScript<!-- and CSS-->.
+Lints your JavaScript.
 
-### JavaScript
-
-```Shell
-npm run lint:js
-```
-
-Only lints your JavaScript.
-
-<!--### CSS
-
-```Shell
-npm run lint:css
-```
-
-Only lints your CSS.-->

--- a/internals/config.js
+++ b/internals/config.js
@@ -4,7 +4,7 @@ const uniq = require('lodash/uniq');
 
 const ReactBoilerplate = {
   // This refers to the react-boilerplate version this project is based on.
-  version: '3.2.1',
+  version: '3.3.0',
 
   /**
    * The DLL Plugin provides a dramatic speed increase to webpack build and hot module reloading

--- a/internals/config.js
+++ b/internals/config.js
@@ -4,7 +4,7 @@ const uniq = require('lodash/uniq');
 
 const ReactBoilerplate = {
   // This refers to the react-boilerplate version this project is based on.
-  version: '3.3.1:',
+  version: '3.3.3',
 
   /**
    * The DLL Plugin provides a dramatic speed increase to webpack build and hot module reloading

--- a/internals/config.js
+++ b/internals/config.js
@@ -4,7 +4,7 @@ const uniq = require('lodash/uniq');
 
 const ReactBoilerplate = {
   // This refers to the react-boilerplate version this project is based on.
-  version: '3.3.0',
+  version: '3.3.1:',
 
   /**
    * The DLL Plugin provides a dramatic speed increase to webpack build and hot module reloading

--- a/internals/generators/language/app-locale.hbs
+++ b/internals/generators/language/app-locale.hbs
@@ -1,2 +1,1 @@
-$1
-  '{{language}}',
+$1  '{{language}}',

--- a/internals/generators/language/index.js
+++ b/internals/generators/language/index.js
@@ -30,7 +30,7 @@ module.exports = {
     actions.push({
       type: 'modify',
       path: '../../app/i18n.js',
-      pattern: /([\n\s'[a-z]+',)(?!.*[\n\s'[a-z]+',)/g,
+      pattern: /(\s+'[a-z]+',\n)(?!.*\s+'[a-z]+',)/g,
       templateFile: './language/app-locale.hbs',
     });
     actions.push({

--- a/internals/scripts/clean.js
+++ b/internals/scripts/clean.js
@@ -1,5 +1,5 @@
 require('shelljs/global');
-const addCheckMark = require('./helpers/checkmark.js'); 
+const addCheckMark = require('./helpers/checkmark.js');
 
 if (!which('git')) {
   echo('Sorry, this script requires git');
@@ -22,6 +22,7 @@ mkdir('-p', 'app/containers/App');
 mkdir('-p', 'app/containers/NotFoundPage');
 mkdir('-p', 'app/containers/HomePage');
 cp('internals/templates/appContainer.js', 'app/containers/App/index.js');
+cp('internals/templates/constants.js', 'app/containers/App/constants.js');
 cp('internals/templates/notFoundPage/notFoundPage.js', 'app/containers/NotFoundPage/index.js');
 cp('internals/templates/notFoundPage/messages.js', 'app/containers/NotFoundPage/messages.js');
 cp('internals/templates/homePage/homePage.js', 'app/containers/HomePage/index.js');

--- a/internals/templates/constants.js
+++ b/internals/templates/constants.js
@@ -1,0 +1,12 @@
+/*
+ * AppConstants
+ * Each action has a corresponding type, which the reducer knows and picks up on.
+ * To avoid weird typos between the reducer and the actions, we save them as
+ * constants here. We prefix them with 'yourproject/YourComponent' so we avoid
+ * reducers accidentally picking up actions they shouldn't.
+ *
+ * Follow this format:
+ * export const YOUR_ACTION_CONSTANT = 'yourproject/YourContainer/YOUR_ACTION_CONSTANT';
+ */
+
+export const DEFAULT_LOCALE = 'en';

--- a/internals/templates/i18n.js
+++ b/internals/templates/i18n.js
@@ -5,7 +5,7 @@
  *
  */
 import { addLocaleData } from 'react-intl';
-import { DEFAULT_LOCALE } from 'containers/App/constants';
+import { DEFAULT_LOCALE } from './containers/App/constants'; // eslint-disable-line
 
 import enLocaleData from 'react-intl/locale-data/en';
 

--- a/internals/templates/languageProvider/constants.js
+++ b/internals/templates/languageProvider/constants.js
@@ -5,3 +5,4 @@
  */
 
 export const CHANGE_LOCALE = 'app/LanguageToggle/CHANGE_LOCALE';
+export const DEFAULT_LOCALE = 'en';

--- a/internals/templates/languageProvider/reducer.js
+++ b/internals/templates/languageProvider/reducer.js
@@ -8,9 +8,12 @@ import { fromJS } from 'immutable';
 import {
   CHANGE_LOCALE,
 } from './constants';
+import {
+  DEFAULT_LOCALE,
+} from '../App/constants'; // eslint-disable-line
 
 const initialState = fromJS({
-  locale: 'en',
+  locale: DEFAULT_LOCALE,
 });
 
 function languageProviderReducer(state = initialState, action) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-boilerplate",
-  "version": "3.3.1",
+  "version": "3.3.3",
   "description": "A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-boilerplate",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-boilerplate",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removed referenced to lint:css, which is currently not supported.