### PR TITLE
Support OpenType fonts with .otf file extension

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -27,7 +27,7 @@ module.exports = (options) => ({
       include: /node_modules/,
       loaders: ['style-loader', 'css-loader'],
     }, {
-      test: /\.(eot|svg|ttf|woff|woff2)$/,
+      test: /\.(eot|svg|otf|ttf|woff|woff2)$/,
       loader: 'file-loader',
     }, {
       test: /\.(jpg|png|gif)$/,


### PR DESCRIPTION
This little fix protects newcomers from going into webpack hell if they include `.otf` fonts. The format is similar to `.ttf`: http://superuser.com/questions/96390/difference-between-otf-open-type-or-ttf-true-type-font-formats