### PR TITLE
Fix broken redux-saga link

### DIFF
--- a/docs/general/introduction.md
+++ b/docs/general/introduction.md
@@ -17,7 +17,7 @@ Here's a curated list of packages that you should have knowledge of, before star
 - [ ] [React](https://facebook.github.io/react/)
 - [ ] [React Router](https://github.com/ReactTraining/react-router)
 - [ ] [Redux](http://redux.js.org/)
-- [ ] [Redux Saga](http://yelouafi.github.io/redux-saga/)
+- [ ] [Redux Saga](https://github.com/redux-saga/redux-saga)
 - [ ] [Reselect](https://github.com/reactjs/reselect)
 - [ ] [ImmutableJS](https://facebook.github.io/immutable-js/)
 - [ ] [Styled Components](https://github.com/styled-components/styled-components)


### PR DESCRIPTION
It appears that redux saga has moved its repository

## React Boilerplate

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/mxstbr/react-boilerplate/blob/master/.github/CONTRIBUTING.md)
- [ ] double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/mxstbr/react-boilerplate/blob/master/LICENSE.md).
