### PR TITLE
Docs Update: sass.md | New webpack version -loader suffix

### DIFF
--- a/docs/css/sass.md
+++ b/docs/css/sass.md
@@ -14,7 +14,7 @@ to the loaders section in `internals/webpack/webpack.base.babel.js` so it reads 
    {
       test: /\.scss$/,
       exclude: /node_modules/,
-      loaders: ['style-loader', 'css-loader', 'sass-loader']
+      rules: ['style-loader', 'css-loader', 'sass-loader']
     }
     ```
 

--- a/docs/css/sass.md
+++ b/docs/css/sass.md
@@ -9,12 +9,12 @@ out into JS where we believe those features belong.
 If you _really_ still want (or need) to use Sass then...
 
 1. You will need to add a [sass-loader](https://github.com/jtangelder/sass-loader)
-to the loaders section in `internals/webpack/webpack.base.babel.js` so it reads something like
+to the loaders/rules section in `internals/webpack/webpack.base.babel.js` so it reads something like
    ```javascript
    {
       test: /\.scss$/,
       exclude: /node_modules/,
-      rules: ['style-loader', 'css-loader', 'sass-loader']
+      loaders: ['style-loader', 'css-loader', 'sass-loader']
     }
     ```
 

--- a/docs/css/sass.md
+++ b/docs/css/sass.md
@@ -14,7 +14,7 @@ to the loaders section in `internals/webpack/webpack.base.babel.js` so it reads 
    {
       test: /\.scss$/,
       exclude: /node_modules/,
-      loaders: ['style', 'css', 'sass']
+      loaders: ['style-loader', 'css-loader', 'sass-loader']
     }
     ```
 


### PR DESCRIPTION
New webpack version no longer allowed to omit the '-loader' suffix when using loaders.
